### PR TITLE
[366] Mobile tiles

### DIFF
--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -244,14 +244,16 @@ $card-text-hover-color: govuk-colour("purple");
 }
 
 .dfe-card-header {
-  margin-bottom: 0;
   padding: govuk-spacing(4);
   padding-bottom: 0;
+  margin: 0;
   color: govuk-colour("white");
   font-weight: bold;
+  font-size: 19px;
 
   @include govuk-media-query($from: tablet) {
-    padding: govuk-spacing(7);
+    font-size: 22px;
+    padding: govuk-spacing(6);
   }
 }
 

--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -253,7 +253,7 @@ $card-text-hover-color: govuk-colour("purple");
 
   @include govuk-media-query($from: tablet) {
     font-size: 22px;
-    padding: govuk-spacing(6);
+    padding: govuk-spacing(7) govuk-spacing(6);
   }
 }
 

--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -183,6 +183,7 @@ $card-text-hover-color: govuk-colour("purple");
 
 .dfe-card {
   display: flex;
+  align-items: center;
   width: 100%;
   margin: govuk-spacing(3);
   background-color: #347ca9;

--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -184,7 +184,7 @@ $card-text-hover-color: govuk-colour("purple");
 .dfe-card {
   display: flex;
   width: 100%;
-  margin: 30px;
+  margin: govuk-spacing(3);
   background-color: #347ca9;
   text-decoration: none;
 

--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -182,15 +182,24 @@ $card-text-hover-color: govuk-colour("purple");
 }
 
 .dfe-card {
-  margin: 40px;
-  border: 1px solid #b1b4b6;
+  display: flex;
+  width: 100%;
+  margin: 30px;
+  background-color: #347ca9;
   text-decoration: none;
+
+  @include govuk-media-query($from: tablet) {
+    margin: 20px;
+    border: 1px solid #b1b4b6;
+  }
+}
+
+.dfe-card-content {
   width: 100%;
 }
 
 .dfe-card--clickable {
   box-shadow: none !important;
-  background-color: govuk-colour("white") !important;
 
   &:hover,
   &:active {
@@ -210,57 +219,79 @@ $card-text-hover-color: govuk-colour("purple");
 
   &:focus {
     .dfe-card-header {
-      color: black;
+      color: govuk-colour("black");
       background-color: $govuk-focus-colour;
       text-decoration: underline;
     }
 
     .dfe-card-body {
-      background-color: govuk-colour("white");
+      background-color: $govuk-focus-colour;
+      p {
+        color: govuk-colour("black");
+      }
+
+      @include govuk-media-query($from: tablet) {
+        background-color: govuk-colour("white");
+      }
     }
   }
 }
 
-.govuk-grid-column-one-third .dfe-card {
-  margin: 20px;
-}
-
 .govuk-grid-column-one-third .dfe-card-body {
-  min-height: 100px;
+  @include govuk-media-query($from: tablet) {
+    min-height: 100px;
+  }
 }
 
 .dfe-card-header {
-  background-color: #347ca9;
-  padding: govuk-spacing(4);
-  color: govuk-colour("white");
-  text-decoration: none;
-  font-weight: bold;
-  padding: govuk-spacing(7);
   margin-bottom: 0;
-}
-
-.dfe-card-header .govuk-heading-m {
+  padding: govuk-spacing(4);
+  padding-bottom: 0;
   color: govuk-colour("white");
-  margin: 20px;
-}
+  font-weight: bold;
 
-.dfe-card-header .govuk-heading-s {
-  color: govuk-colour("white");
-  margin: 20px;
-}
-
-.dfe-card-header--pink {
-  background-color: #d4357f;
-}
-
-.dfe-card-header--purple {
-  background-color: govuk-colour("purple");
-}
-
-.dfe-card-header--green {
-  background-color: #279b91;
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(7);
+  }
 }
 
 .dfe-card-body {
-  padding: govuk-spacing(7);
+  padding: govuk-spacing(4);
+  padding-top: govuk-spacing(3);
+
+  p {
+    color: govuk-colour("white");
+    margin-bottom: 0;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(7);
+    background-color: govuk-colour("white");
+
+    p {
+      margin-bottom: govuk-spacing(7);
+      color: $govuk-text-colour;
+    }
+  }
+}
+
+.dfe-card__chevron {
+  margin: 0 govuk-spacing(4);
+  max-width: 20px;
+
+  @include govuk-media-query($from: tablet) {
+    display: none;
+  }
+}
+
+.dfe-card--pink {
+  background-color: #d4357f;
+}
+
+.dfe-card--purple {
+  background-color: govuk-colour("purple");
+}
+
+.dfe-card--green {
+  background-color: #279b91;
 }

--- a/content/main.html.erb
+++ b/content/main.html.erb
@@ -29,14 +29,14 @@ title: Home
   <div class="govuk-width-container dfe-width-container">
     <ul class="govuk-grid-row card-group">
       <li class="govuk-grid-column-one-half card-group__item govuk-!-padding-4">
-        <%= render('/partials/tile.*', title: "Workload reduction toolkit", title_size: "l",
+        <%= render('/partials/tile.*', title: "Workload reduction toolkit",
           body: "Support workload reduction with resources produced by school leaders.",
           href: "#{@base_url}/workload-reduction-toolkit"
         ) %>
       </li>
 
       <li class="govuk-grid-column-one-half card-group__item govuk-!-padding-4">
-        <%= render('/partials/tile.*', title: "Staff wellbeing", title_size: "l",
+        <%= render('/partials/tile.*', title: "Staff wellbeing",
           body: "Promote a culture of wellbeing with resources made by school leaders.",
           href: "#{@base_url}/staff-wellbeing"
         ) %>

--- a/content/main.html.erb
+++ b/content/main.html.erb
@@ -30,23 +30,33 @@ title: Home
     <ul class="govuk-grid-row card-group">
       <li class="govuk-grid-column-one-half card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit">
-          <h2 class="govuk-body-l dfe-card-header">
-            Workload reduction toolkit
-          </h2>
-          <div class="dfe-card-body">
-            <p class="govuk-body">Support workload reduction with resources produced by school leaders.</p>
+          <div class="dfe-card__content">
+            <h2 class="govuk-body-l dfe-card-header">
+              Workload reduction toolkit
+            </h2>
+            <div class="dfe-card-body">
+              <p class="govuk-body">Support workload reduction with resources produced by school leaders.</p>
+            </div>
           </div>
+          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
+          </svg>
         </a>
       </li>
 
       <li class="govuk-grid-column-one-half card-group__item">
         <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/staff-wellbeing">
-          <h2 class="govuk-body-l dfe-card-header">
-            Staff wellbeing
-          </h2>
-          <div class="dfe-card-body">
-            <p class="govuk-body">Promote a culture of wellbeing with resources made by school leaders.</p>
+          <div class="dfe-card__content">
+            <h2 class="govuk-body-l dfe-card-header">
+              Staff wellbeing
+            </h2>
+            <div class="dfe-card-body">
+              <p class="govuk-body">Promote a culture of wellbeing with resources made by school leaders.</p>
+            </div>
           </div>
+          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
+          </svg>
         </a>
       </li>
     </ul>

--- a/content/main.html.erb
+++ b/content/main.html.erb
@@ -28,36 +28,18 @@ title: Home
 <div class="govuk-main-wrapper">
   <div class="govuk-width-container dfe-width-container">
     <ul class="govuk-grid-row card-group">
-      <li class="govuk-grid-column-one-half card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit">
-          <div class="dfe-card__content">
-            <h2 class="govuk-body-l dfe-card-header">
-              Workload reduction toolkit
-            </h2>
-            <div class="dfe-card-body">
-              <p class="govuk-body">Support workload reduction with resources produced by school leaders.</p>
-            </div>
-          </div>
-          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
-          </svg>
-        </a>
+      <li class="govuk-grid-column-one-half card-group__item govuk-!-padding-4">
+        <%= render('/partials/tile.*', title: "Workload reduction toolkit", title_size: "l",
+          body: "Support workload reduction with resources produced by school leaders.",
+          href: "#{@base_url}/workload-reduction-toolkit"
+        ) %>
       </li>
 
-      <li class="govuk-grid-column-one-half card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/staff-wellbeing">
-          <div class="dfe-card__content">
-            <h2 class="govuk-body-l dfe-card-header">
-              Staff wellbeing
-            </h2>
-            <div class="dfe-card-body">
-              <p class="govuk-body">Promote a culture of wellbeing with resources made by school leaders.</p>
-            </div>
-          </div>
-          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
-          </svg>
-        </a>
+      <li class="govuk-grid-column-one-half card-group__item govuk-!-padding-4">
+        <%= render('/partials/tile.*', title: "Staff wellbeing", title_size: "l",
+          body: "Promote a culture of wellbeing with resources made by school leaders.",
+          href: "#{@base_url}/staff-wellbeing"
+        ) %>
       </li>
     </ul>
   </div>

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -34,41 +34,56 @@ title: Workload reduction toolkit
 
     <ul class="govuk-grid-row card-group">
       <li class="govuk-grid-column-one-third card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/identify-workload-issues">
-          <h3 class="dfe-card-header dfe-card-header--pink govuk-body">
-            Identify workload issues
-          </h3>
-          <div class="dfe-card-body">
-            <p class="govuk-body">
-              Identify workload issues and prioritise where to act
-            </p>
+        <a class="dfe-card dfe-card--pink dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/identify-workload-issues">
+          <div class="dfe-card-content">
+            <h3 class="dfe-card-header govuk-body">
+              Identify workload issues
+            </h3>
+            <div class="dfe-card-body">
+              <p class="govuk-body">
+                Identify workload issues and prioritise where to act
+              </p>
+            </div>
           </div>
+          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
+          </svg>
         </a>
       </li>
 
       <li class="govuk-grid-column-one-third card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/address-workload-issues">
-          <h3 class="dfe-card-header dfe-card-header--purple govuk-body">
-            Address workload issues
-          </h3>
-          <div class="dfe-card-body">
-            <p class="govuk-body">
-              Take action to reduce workload
-            </p>
+        <a class="dfe-card dfe-card--purple dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/address-workload-issues">
+          <div class="dfe-card-content">
+            <h3 class="dfe-card-header govuk-body">
+              Address workload issues
+            </h3>
+            <div class="dfe-card-body">
+              <p class="govuk-body">
+                Take action to reduce workload
+              </p>
+            </div>
           </div>
+          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
+          </svg>
         </a>
       </li>
 
       <li class="govuk-grid-column-one-third card-group__item">
-        <a class="dfe-card dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/evaluate-workload-measures">
-          <h3 class="dfe-card-header dfe-card-header--green govuk-body">
-            Evaluate workload measures
-          </h3>
-          <div class="dfe-card-body">
-            <p class="govuk-body">
-              Track and evaluate workload reduction measures
-            </p>
+        <a class="dfe-card dfe-card--green dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/evaluate-workload-measures">
+          <div class="dfe-card-content">
+            <h3 class="dfe-card-header govuk-body">
+              Evaluate workload measures
+            </h3>
+            <div class="dfe-card-body">
+              <p class="govuk-body">
+                Track and evaluate workload reduction measures
+              </p>
+            </div>
           </div>
+          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
+          </svg>
         </a>
       </li>
     </ul>

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -34,57 +34,27 @@ title: Workload reduction toolkit
 
     <ul class="govuk-grid-row card-group">
       <li class="govuk-grid-column-one-third card-group__item">
-        <a class="dfe-card dfe-card--pink dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/identify-workload-issues">
-          <div class="dfe-card-content">
-            <h3 class="dfe-card-header govuk-body">
-              Identify workload issues
-            </h3>
-            <div class="dfe-card-body">
-              <p class="govuk-body">
-                Identify workload issues and prioritise where to act
-              </p>
-            </div>
-          </div>
-          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
-          </svg>
-        </a>
+        <%= render('/partials/tile.*', title: "Identify workload issues",
+          body: "Identify workload issues and prioritise where to act",
+          href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues",
+          colour: "pink"
+        ) %>
       </li>
 
       <li class="govuk-grid-column-one-third card-group__item">
-        <a class="dfe-card dfe-card--purple dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/address-workload-issues">
-          <div class="dfe-card-content">
-            <h3 class="dfe-card-header govuk-body">
-              Address workload issues
-            </h3>
-            <div class="dfe-card-body">
-              <p class="govuk-body">
-                Take action to reduce workload
-              </p>
-            </div>
-          </div>
-          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
-          </svg>
-        </a>
+        <%= render('/partials/tile.*', title: "Address workload issues",
+          body: "Take action to reduce workload",
+          href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues",
+          colour: "purple"
+        ) %>
       </li>
 
       <li class="govuk-grid-column-one-third card-group__item">
-        <a class="dfe-card dfe-card--green dfe-card--clickable govuk-link--no-visited-state" href="<%= @base_url %>/workload-reduction-toolkit/evaluate-workload-measures">
-          <div class="dfe-card-content">
-            <h3 class="dfe-card-header govuk-body">
-              Evaluate workload measures
-            </h3>
-            <div class="dfe-card-body">
-              <p class="govuk-body">
-                Track and evaluate workload reduction measures
-              </p>
-            </div>
-          </div>
-          <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
-          </svg>
-        </a>
+        <%= render('/partials/tile.*', title: "Evaluate workload measures",
+          body: "Track and evaluate workload reduction measures",
+          href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures",
+          colour: "green"
+        ) %>
       </li>
     </ul>
   </div>

--- a/layouts/partials/tile.html.erb
+++ b/layouts/partials/tile.html.erb
@@ -1,0 +1,15 @@
+<a class="dfe-card <%= defined?(colour) ? 'dfe-card--' + colour : nil %> dfe-card--clickable govuk-link--no-visited-state" href="<%= href %>">
+  <div class="dfe-card-content">
+    <h2 class="dfe-card-header govuk-body-<%= defined?(title_size) ? title_size : 'm' %>">
+      <%= title %>
+    </h2>
+    <div class="dfe-card-body">
+      <p class="govuk-body">
+        <%= body %>
+      </p>
+    </div>
+  </div>
+  <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
+  </svg>
+</a>

--- a/layouts/partials/tile.html.erb
+++ b/layouts/partials/tile.html.erb
@@ -1,6 +1,6 @@
 <a class="dfe-card <%= defined?(colour) ? 'dfe-card--' + colour : nil %> dfe-card--clickable govuk-link--no-visited-state" href="<%= href %>">
   <div class="dfe-card-content">
-    <h2 class="dfe-card-header govuk-body-<%= defined?(title_size) ? title_size : 'm' %>">
+    <h2 class="dfe-card-header">
       <%= title %>
     </h2>
     <div class="dfe-card-body">

--- a/layouts/partials/tile.html.erb
+++ b/layouts/partials/tile.html.erb
@@ -9,7 +9,7 @@
       </p>
     </div>
   </div>
-  <svg class="dfe-card__chevron" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg class="dfe-card__chevron" width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#ffffff" stroke-width="2"/>
   </svg>
 </a>


### PR DESCRIPTION
## Changes in this PR

- Add new mobile styles for the tiles on both the homepage and the workload toolkit
- Move tiles into reusable partial

## Guidance to review

- Check that there are no regressions on desktop
- Check styles on mobile

New mobile style:

<img width="535" alt="Screenshot 2024-03-13 at 14 55 34" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/ade137e1-5c7a-4c37-8e37-6e4283cd13fb">
<img width="534" alt="Screenshot 2024-03-13 at 14 55 43" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/d2a80845-6163-4f65-81e7-533213ae8a07">
