### PR TITLE
[xxx] Tweak to css on markdown pages

### DIFF
--- a/content/assets/css/_info-box.scss
+++ b/content/assets/css/_info-box.scss
@@ -32,7 +32,7 @@
   }
 }
 
-.markdown-page {
+.markdown-resource {
   .info-box {
     margin-bottom: govuk-spacing(2);
 

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -303,7 +303,7 @@ main {
   }
 }
 
-.markdown-page {
+.markdown-resource {
   .govuk-heading-m {
     @include govuk-responsive-margin(8, "top");
   }
@@ -311,10 +311,10 @@ main {
   hr {
     border-width: 4px;
   }
+}
 
-  hr.section-break--thin {
-    border-width: 2px;
-  }
+hr.section-break--thin {
+  border-width: 2px;
 }
 
 .content__section--grey {
@@ -381,7 +381,7 @@ main {
   background-color: #279b91;
 }
 
-.markdown-page {
+.markdown-resource {
   .govuk-tag {
     margin-bottom: govuk-spacing(4);
   }
@@ -430,7 +430,7 @@ main {
   }
 }
 
-.markdown-page {
+.markdown-resource {
   h1 {
     margin-bottom: govuk-spacing(3);
   }

--- a/layouts/markdown_layout.html.erb
+++ b/layouts/markdown_layout.html.erb
@@ -1,6 +1,6 @@
 <% wrapped_content=capture do %>
   <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row govuk-width-container dfe-width-container markdown-page">
+    <div class="govuk-grid-row govuk-width-container dfe-width-container">
       <div class="govuk-grid-column-two-thirds">
         <%= yield %>
       </div>

--- a/layouts/markdown_resource.html.erb
+++ b/layouts/markdown_resource.html.erb
@@ -1,6 +1,6 @@
 <% wrapped_content=capture do %>
   <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row govuk-width-container dfe-width-container markdown-page content-section--<%= @item[:colour] ?  @item[:colour] : 'purple' %> two-column-page">
+    <div class="govuk-grid-row govuk-width-container dfe-width-container markdown-resource content-section--<%= @item[:colour] ?  @item[:colour] : 'purple' %> two-column-page">
       <div class="govuk-grid-column-two-thirds">
         <%= yield %>
         <%= render '/partials/share_this_resource.*' %>


### PR DESCRIPTION
## Changes in this PR

1. Remove the `.markdown-page` class from the `markdown_layout` file.

This layout is only used by **two (non resource) pages**:
- Supporting staff mental health in schools `/staff-wellbeing/supporting-staff-mental-health/`
- Accessibility statement 

Neither of these pages need the css that this class applies (most obviously the large margins around h2s)

2. Rename the class `.markdown-resource` so it more accurately reflects what it encompasses