### PR TITLE
Fix `base_url` in partials

### DIFF
--- a/layouts/partials/cookies_banner.html.erb
+++ b/layouts/partials/cookies_banner.html.erb
@@ -1,5 +1,14 @@
-<div class="govuk-cookie-banner" role="region" aria-label="Cookies banner" data-nosnippet hidden data-module="cookie-banner">
-  <div class="govuk-cookie-banner__message govuk-width-container dfe-width-container">
+<div
+  class="govuk-cookie-banner"
+  role="region"
+  aria-label="Cookies banner"
+  data-nosnippet
+  hidden
+  data-module="cookie-banner"
+>
+  <div
+    class="govuk-cookie-banner__message govuk-width-container dfe-width-container"
+  >
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-cookie-banner__heading govuk-heading-m">
@@ -17,19 +26,40 @@
       </div>
     </div>
     <div class="govuk-button-group">
-      <button value="yes" type="button" class="govuk-button" data-module="govuk-button">
+      <button
+        value="yes"
+        type="button"
+        class="govuk-button"
+        data-module="govuk-button"
+      >
         Accept analytics cookies
       </button>
-      <button value="no" type="button" class="govuk-button" data-module="govuk-button">
+      <button
+        value="no"
+        type="button"
+        class="govuk-button"
+        data-module="govuk-button"
+      >
         Reject analytics cookies
       </button>
-      <a class="govuk-link" href="<%= @base_url %>/cookie-policy">View cookies</a>
+      <a class="govuk-link" href="<%= base_url %>/cookie-policy"
+        >View cookies</a
+      >
     </div>
   </div>
 </div>
 
-<div class="govuk-cookie-banner govuk-!-display-none-print" role="region" aria-label="Cookies banner" data-nosnippet hidden data-module="after-consent-cookie-banner">
-  <div class="govuk-cookie-banner__message govuk-width-container dfe-width-container">
+<div
+  class="govuk-cookie-banner govuk-!-display-none-print"
+  role="region"
+  aria-label="Cookies banner"
+  data-nosnippet
+  hidden
+  data-module="after-consent-cookie-banner"
+>
+  <div
+    class="govuk-cookie-banner__message govuk-width-container dfe-width-container"
+  >
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-cookie-banner__content">
@@ -37,13 +67,23 @@
             You’ve
             <span class="decision accepted">accepted</span>
             <span class="decision rejected">rejected</span>
-            analytics cookies.
-            You can <a class="govuk-link" href="<%= @base_url %>/cookie-policy">change your cookie settings</a> at any time.</p>
+            analytics cookies. You can
+            <a class="govuk-link" href="<%= base_url %>/cookie-policy"
+              >change your cookie settings</a
+            >
+            at any time.
+          </p>
         </div>
       </div>
     </div>
     <div class="govuk-button-group">
-      <button value="yes" type="submit" name="cookies[hide]" class="govuk-button cookie-button" data-module="govuk-button">
+      <button
+        value="yes"
+        type="submit"
+        name="cookies[hide]"
+        class="govuk-button cookie-button"
+        data-module="govuk-button"
+      >
         Hide cookie message
       </button>
     </div>

--- a/layouts/partials/feedback.html.erb
+++ b/layouts/partials/feedback.html.erb
@@ -2,7 +2,7 @@
   <div class="feedback-section">
     <div class="feedback-section__icon">
       <img
-        src="<%= @base_url %>/assets/images/idea-icon-<%= defined?(colour) ? colour : 'blue' %>.svg"
+        src="<%= base_url %>/assets/images/idea-icon-<%= defined?(colour) ? colour : 'blue' %>.svg"
         alt="Idea icon"
         class="dfe-icon"
       />
@@ -14,7 +14,10 @@
         school.
       </p>
       <p class="govuk-body">
-        <a href="<%= @base_url %>/share-your-ideas" class="govuk-link govuk-link--no-visited-state">
+        <a
+          href="<%= base_url %>/share-your-ideas"
+          class="govuk-link govuk-link--no-visited-state"
+        >
           Share your ideas
         </a>
       </p>
@@ -22,7 +25,11 @@
   </div>
   <div class="feedback-section">
     <div class="feedback-section__icon">
-      <img src="<%= @base_url %>/assets/images/chat-icon-<%= defined?(colour) ? colour : 'blue' %>.svg" alt="Chat icon" class="dfe-icon" />
+      <img
+        src="<%= base_url %>/assets/images/chat-icon-<%= defined?(colour) ? colour : 'blue' %>.svg"
+        alt="Chat icon"
+        class="dfe-icon"
+      />
     </div>
     <div class="feedback-section__content">
       <h3 class="govuk-heading-m">Help improve our service</h3>
@@ -31,7 +38,10 @@
         for all school staff.
       </p>
       <p class="govuk-body">
-        <a href="https://forms.office.com/e/sEhZxVyw29" class="govuk-link govuk-link--no-visited-state">
+        <a
+          href="https://forms.office.com/e/sEhZxVyw29"
+          class="govuk-link govuk-link--no-visited-state"
+        >
           Complete our feedback form
         </a>
       </p>

--- a/layouts/partials/share_this_resource.html.erb
+++ b/layouts/partials/share_this_resource.html.erb
@@ -2,7 +2,7 @@
 <div class="share-resource-container">
   <div class="share-resource">
     <div class="share-resource__icon <%= @item[:colour] ? 'share-resource__icon--' + @item[:colour] : nil %>">
-      <img src="<%= @base_url %>/assets/images/link-icon.svg" alt="Link icon"/>
+      <img src="<%= base_url %>/assets/images/link-icon.svg" alt="Link icon"/>
     </div>
     <button onclick="window.navigator.clipboard.writeText(window.location.href);" class="button-link">
       Copy link
@@ -10,8 +10,8 @@
   </div>
   <div class="share-resource">
     <div class="share-resource__icon <%= @item[:colour] ? 'share-resource__icon--' + @item[:colour] : nil %>">
-      <img src="<%= @base_url %>/assets/images/mail-icon.svg" alt="Mail icon"/>
+      <img src="<%= base_url %>/assets/images/mail-icon.svg" alt="Mail icon"/>
     </div>
-    <a href="mailto:school.workloadandwellbeing@education.gov.uk?subject=Resource to help with workload and wellbeing for school staff&body=Check out <%= @item[:title] %> to help improve workload and wellbeing for staff in your school: <%= @base_url %><%= @item.path %>">Email</a>
+    <a href="mailto:school.workloadandwellbeing@education.gov.uk?subject=Resource to help with workload and wellbeing for school staff&body=Check out <%= @item[:title] %> to help improve workload and wellbeing for staff in your school: <%= base_url %><%= @item.path %>">Email</a>
   </div>
 </div>

--- a/layouts/partials/topic_list.html.erb
+++ b/layouts/partials/topic_list.html.erb
@@ -1,43 +1,83 @@
 <div class="topic-list">
   <h2 class="govuk-heading-m">Topics</h2>
   <ul class="govuk-list">
-    <li class="<%= active == 'identify-workload-issues' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/explore-all-resources/identify-workload-issues">
+    <li
+      class="<%= active == 'identify-workload-issues' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/identify-workload-issues"
+      >
         Identify workload issues
       </a>
     </li>
-    <li class="<%= active == 'data-management' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/explore-all-resources/data-management">
+    <li
+      class="<%= active == 'data-management' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/data-management"
+      >
         Data management
       </a>
     </li>
-    <li class="<%= active == 'feedback-and-marking' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/explore-all-resources/feedback-and-marking">
+    <li
+      class="<%= active == 'feedback-and-marking' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/feedback-and-marking"
+      >
         Feedback and marking
       </a>
     </li>
-    <li class="<%= active == 'curriculum-planning-and-delivery' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/explore-all-resources/curriculum-planning-and-delivery">
+    <li
+      class="<%= active == 'curriculum-planning-and-delivery' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/curriculum-planning-and-delivery"
+      >
         Curriculum planning and delivery
       </a>
     </li>
-    <li class="<%= active == 'behaviour-management' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/explore-all-resources/behaviour-management">
+    <li
+      class="<%= active == 'behaviour-management' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/behaviour-management"
+      >
         Behaviour management
       </a>
     </li>
-    <li class="<%= active == 'communications' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/explore-all-resources/communications">
+    <li
+      class="<%= active == 'communications' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/communications"
+      >
         Communications
       </a>
     </li>
-    <li class="<%= active == 'evaluate-workload-measures' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state" href="<%= @base_url %>/explore-all-resources/evaluate-workload-measures">
+    <li
+      class="<%= active == 'evaluate-workload-measures' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/evaluate-workload-measures"
+      >
         Evaluate workload measures
       </a>
     </li>
-    <li class="<%= active == 'staff-wellbeing' ? 'topic-list__item-active' : 'topic-list__item' %>">
-      <a class="govuk-link govuk-link--no-visited-state"href="<%= @base_url %>/explore-all-resources/staff-wellbeing">
+    <li
+      class="<%= active == 'staff-wellbeing' ? 'topic-list__item-active' : 'topic-list__item' %>"
+    >
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="<%= base_url %>/explore-all-resources/staff-wellbeing"
+      >
         Staff wellbeing
       </a>
     </li>

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -6,3 +6,7 @@ use_helper Nanoc::Helpers::Rendering
 use_helper Nanoc::Helpers::LinkTo
 use_helper Nanoc::Helpers::Breadcrumbs
 use_helper NavigationHelper
+
+def base_url
+  @config[:base_url]
+end


### PR DESCRIPTION
## Card

[Fix the email link on individual resources](https://trello.com/c/wFYSScv2)

## Summary

`@base_url` is not processed in partials. We could see the result of this when clicking the "Email" link in the partial `layouts/partials/share_this_resource.html.erb`. The result being that the base path of the URl was missing.

To resolve this we have added a helper method `base_url` to `layouts/partials/share_this_resource.html.erb` and updated occurrences of `@base_url` in partials to `base_url`.

## Guidance to review

Check:

- [ ] "View cookies" link in the cookie banner
- [ ] "Share your ideas" in feedback
- [ ] "Copy link" in share resource section
- [ ] "Email" in share resource section
- [ ] Topic links in "Explore all resources"