### PR TITLE
[327] Fix layouts on mobile, including info box widths

### DIFF
--- a/content/assets/css/_feedback-sections.scss
+++ b/content/assets/css/_feedback-sections.scss
@@ -12,7 +12,7 @@
 
   .feedback-section {
     margin: 0;
-    padding-top: govuk-spacing(2);
+    padding: govuk-spacing(2) 0 govuk-spacing(8) 0;
   }
 
   .feedback-section__icon {
@@ -26,8 +26,9 @@
   width: 100%;
   display: flex;
   margin-top: govuk-spacing(4);
+
   @include govuk-media-query($from: tablet) {
-    margin: 0 govuk-spacing(6);
+    margin: govuk-spacing(4) govuk-spacing(6) 0 govuk-spacing(6);
   }
 }
 

--- a/content/assets/css/_info-box.scss
+++ b/content/assets/css/_info-box.scss
@@ -2,8 +2,14 @@
   position: relative;
   background-color: govuk-colour("light-grey");
   border-top: 8px solid govuk-colour("blue");
-  padding: govuk-spacing(7) govuk-spacing(9) govuk-spacing(4) govuk-spacing(9);
-  margin: govuk-spacing(8) 0 govuk-spacing(8) govuk-spacing(3);
+  padding: govuk-spacing(6);
+  padding-top: govuk-spacing(7);
+  margin: 60px 0 60px govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin: 80px 0 80px govuk-spacing(3);
+    padding: govuk-spacing(7) govuk-spacing(9) govuk-spacing(4) govuk-spacing(9);
+  }
 
   .govuk-heading-m {
     margin-top: 0;
@@ -13,14 +19,20 @@
 .info-box__corner {
   position: absolute;
   background: govuk-colour("blue");
-  width: 60px;
-  height: 60px;
-  top: -20px;
+  width: 55px;
+  height: 55px;
+  top: -25px;
   left: -15px;
   z-index: 1;
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @include govuk-media-query($from: tablet) {
+    width: 60px;
+    height: 60px;
+    top: -20px;
+  }
 }
 
 .info-box__download-content {
@@ -34,8 +46,6 @@
 
 .markdown-resource {
   .info-box {
-    margin-bottom: govuk-spacing(2);
-
     h2 {
       margin-top: 0;
     }

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -225,6 +225,11 @@
   width: 100%;
   height: auto;
   object-fit: contain;
+  margin-bottom: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 0;
+  }
 }
 
 .dfe-header__menu-toggle {

--- a/content/main.html.erb
+++ b/content/main.html.erb
@@ -26,8 +26,8 @@ title: Home
 </div>
 
 <div class="govuk-main-wrapper">
-  <div class="govuk-width-container dfe-width-container">
-    <ul class="govuk-grid-row card-group">
+  <div class="dfe-width-container">
+    <ul class="govuk-grid-row card-group govuk-!-margin-bottom-8">
       <li class="govuk-grid-column-one-half card-group__item govuk-!-padding-4">
         <%= render('/partials/tile.*', title: "Workload reduction toolkit",
           body: "Support workload reduction with resources produced by school leaders.",
@@ -43,24 +43,24 @@ title: Home
       </li>
     </ul>
   </div>
-</div>
 
-<div class="dfe-content-page--row">
-  <div class="govuk-grid-row govuk-width-container dfe-width-container">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">Explore all resources</h2>
-      <p class="govuk-body">Browse through all our staff wellbeing and workload reduction resources. They are
+  <div class="dfe-content-page--row">
+    <div class="govuk-grid-row dfe-width-container">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">Explore all resources</h2>
+        <p class="govuk-body">Browse through all our staff wellbeing and workload reduction resources. They are
         contributed by school leaders from their experiences improving workload and wellbeing in their schools.</p>
-      <a class="govuk-button govuk-button--blue govuk-!-margin-top-2" data-module="govuk-button"
-        href="<%= @base_url %>/explore-all-resources/identify-workload-issues">
-        Explore all resources
-      </a>
+        <a class="govuk-button govuk-button--blue govuk-!-margin-top-2" data-module="govuk-button"
+          href="<%= @base_url %>/explore-all-resources/identify-workload-issues">
+          Explore all resources
+        </a>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="dfe-width-container govuk-grid-row govuk-!-margin-top-7">
-  <div class="govuk-grid-column-full">
-    <%= render '/partials/feedback.*' %>
+  <div class="dfe-width-container govuk-grid-row govuk-!-margin-top-9">
+    <div class="govuk-grid-column-full">
+      <%= render '/partials/feedback.*' %>
+    </div>
   </div>
 </div>

--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -22,117 +22,108 @@ title: Staff wellbeing
 
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container">
-
     <div class="govuk-grid-row two-column-page">
       <div class="govuk-grid-column-two-thirds">
-
-        <div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-          <div class="info-box govuk-!-margin-top-6">
-            <div class="info-box__corner">
-              <img src="<%= @base_url %>/assets/images/i-icon.svg" alt="info icon">
-            </div>
-            <h2 class="govuk-heading-m">
-              How to use this section
-            </h2>
-            <p class="govuk-body">
-              Placing staff wellbeing at the centre of everything you do will have positive consequences in all aspects
-              of school life.
-            </p>
-            <p class="govuk-body">
-              The resources provide specific examples which have worked in schools. You can use them as they are, or
-              adapt them to meet the needs of your school.
-            </p>
+        <div class="info-box govuk-!-margin-top-6">
+          <div class="info-box__corner">
+            <img src="<%= @base_url %>/assets/images/i-icon.svg" alt="info icon">
           </div>
+          <h2 class="govuk-heading-m">
+            How to use this section
+          </h2>
+          <p>
+            Placing staff wellbeing at the centre of everything you do will have
+            positive consequences in all aspects of school life.
+          </p>
+          <p>
+            The resources provide specific examples which have worked in
+            schools. You can use them as they are, or adapt them to meet the needs of your school.
+          </p>
         </div>
 
-        <div class="govuk-grid-row dfe-width-container  govuk-!-padding-bottom-0">
-          <h2 class="govuk-heading-m">Resources to help set a wellbeing vision</h2>
-        </div>
+        <h2 class="govuk-heading-m">Resources to help set a wellbeing vision</h2>
 
-        <div class="govuk-grid-row dfe-width-container govuk-!-margin-bottom-3">
-          <ul class="resource-card-group">
-            <%= render('/partials/resource_card.*', title: "Create a school culture which improves wellbeing" , href: "#{@base_url}/staff-wellbeing/create-a-school-culture-which-improves-wellbeing",
-              body: "Learn how to develop a school culture of wellbeing and workload improvement.", tag: "Case study",
-              details: { reading_time: "4 minutes", created_by: "Kensington Primary School" }) %>
+        <ul class="resource-card-group govuk-!-margin-bottom-3">
+          <%= render('/partials/resource_card.*', title: "Create a school culture which improves wellbeing" , href: "#{@base_url}/staff-wellbeing/create-a-school-culture-which-improves-wellbeing",
+            body: "Learn how to develop a school culture of wellbeing and workload improvement.", tag: "Case study",
+            details: { reading_time: "4 minutes", created_by: "Kensington Primary School" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Academy trust workload agreement", href: "#{@base_url}/staff-wellbeing/academy-trust-workload-agreement",
-              body: "Share what teachers can expect in terms of workload, professional development, pay and rewards.",
-              tag: "Example", details: { reading_time: "2 minutes" , created_by: "The Ascent Academies’ Trust" }) %>
+          <%= render('/partials/resource_card.*', title: "Academy trust workload agreement", href: "#{@base_url}/staff-wellbeing/academy-trust-workload-agreement",
+            body: "Share what teachers can expect in terms of workload, professional development, pay and rewards.",
+            tag: "Example", details: { reading_time: "2 minutes" , created_by: "The Ascent Academies’ Trust" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Staff wellbeing policy", href: "#{@base_url}/staff-wellbeing/staff-wellbeing-policy",
-                body: "Read a staff wellbeing policy that reflects a whole school approach to wellbeing.",
-                tag: "Example", details: { reading_time: "6 minutes", created_by: "The Pingle Academy (Secondary)" }) %>
+          <%= render('/partials/resource_card.*', title: "Staff wellbeing policy", href: "#{@base_url}/staff-wellbeing/staff-wellbeing-policy",
+              body: "Read a staff wellbeing policy that reflects a whole school approach to wellbeing.",
+              tag: "Example", details: { reading_time: "6 minutes", created_by: "The Pingle Academy (Secondary)" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Staff wellbeing statement" ,
-                href: "#{@base_url}/staff-wellbeing/staff-wellbeing-statement", body: "Read a wellbeing statement developed to support school staff effectively.",
-                tag: "Example", details: { reading_time: "3 minutes", created_by: "St. Peter’s School (Secondary)" }) %>
+          <%= render('/partials/resource_card.*', title: "Staff wellbeing statement" ,
+              href: "#{@base_url}/staff-wellbeing/staff-wellbeing-statement", body: "Read a wellbeing statement developed to support school staff effectively.",
+              tag: "Example", details: { reading_time: "3 minutes", created_by: "St. Peter’s School (Secondary)" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Wellbeing and workload charter" ,
-              href: "#{@base_url}/staff-wellbeing/wellbeing-and-workload-charter", body: "Read an example wellbeing and workload charter.", tag: "Example",
-              details: { reading_time: "6 minutes", created_by: "Bedford Academy (Secondary)" }) %>
-          </ul>
-        </div>
+          <%= render('/partials/resource_card.*', title: "Wellbeing and workload charter" ,
+            href: "#{@base_url}/staff-wellbeing/wellbeing-and-workload-charter", body: "Read an example wellbeing and workload charter.", tag: "Example",
+            details: { reading_time: "6 minutes", created_by: "Bedford Academy (Secondary)" }) %>
+        </ul>
 
-        <div class="govuk-grid-row dfe-width-container govuk-!-padding-top-6 govuk-!-padding-bottom-0">
-          <h2 class="govuk-heading-m">Resources to support communications on wellbeing</h2>
-        </div>
+        <h2 class="govuk-heading-m govuk-!-padding-top-6 govuk-!-padding-bottom-0">
+          Resources to support communications on wellbeing
+        </h2>
 
-        <div class="govuk-grid-row dfe-width-container">
-          <ul class="resource-card-group">
+        <ul class="resource-card-group">
+          <%= render('/partials/resource_card.*', title: "Establish a wellbeing committee" , href: "#{@base_url}/staff-wellbeing/establish-a-wellbeing-committee",
+            body: "Learn how to set up a wellbeing committee." , tag: "Example",
+            details: { reading_time: "3 minutes", created_by: "Notre Dame High School (Secondary)" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Establish a wellbeing committee" , href: "#{@base_url}/staff-wellbeing/establish-a-wellbeing-committee",
-              body: "Learn how to set up a wellbeing committee." , tag: "Example",
-              details: { reading_time: "3 minutes", created_by: "Notre Dame High School (Secondary)" }) %>
+          <%= render('/partials/resource_card.*', title: "Establish a school workload group" , href: "#{@base_url}/staff-wellbeing/establish-a-school-workload-group" ,
+            body: "Learn how to set up a workload group." , tag: "Example" , details: { reading_time: "3 minutes" ,
+            created_by: "Baylis Court School (Secondary)" }) %>
 
-            <%= render('/partials/resource_card.*', title: "Establish a school workload group" , href: "#{@base_url}/staff-wellbeing/establish-a-school-workload-group" ,
-              body: "Learn how to set up a workload group." , tag: "Example" , details: { reading_time: "3 minutes" ,
-              created_by: "Baylis Court School (Secondary)" }) %>
+          <%= render('/partials/resource_card.*', title: "Communicate about wellbeing to improve staff retention" ,
+            href: "#{@base_url}/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention" , body: "Learn how communication improved staff retention." , tag: "Case study" ,
+            details: { reading_time: "3 minutes" , created_by: "Bedford Academy (Secondary)" }) %>
+        </ul>
 
-            <%= render('/partials/resource_card.*', title: "Communicate about wellbeing to improve staff retention" ,
-              href: "#{@base_url}/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention" , body: "Learn how communication improved staff retention." , tag: "Case study" ,
-              details: { reading_time: "3 minutes" , created_by: "Bedford Academy (Secondary)" }) %>
+        <h2 class="govuk-heading-m govuk-!-padding-top-6 govuk-!-padding-bottom-0">
+          Resources to help you take action
+        </h2>
 
-          </ul>
-        </div>
+        <ul class="resource-card-group">
+          <%= render('/partials/resource_card.*', title: "Protect staff time and improve wellbeing" , href: "#{@base_url}/staff-wellbeing/protect-staff-time-and-improve-wellbeing" ,
+            body: "Read tips on using time effectively to improve wellbeing." , tag: "Case study" , details: {
+            reading_time: "2 minutes" , created_by: "West Meon CofE Primary School" }) %>
 
-        <div class="govuk-grid-row dfe-width-container govuk-!-padding-top-6 govuk-!-padding-bottom-0">
-          <h2 class="govuk-heading-m">Resources to help you take action</h2>
-        </div>
+          <%= render('/partials/resource_card.*', title: "Try ideas to improve staff wellbeing" , href: "#{@base_url}/staff-wellbeing/try-ideas-to-improve-staff-wellbeing" ,
+            body: "Read advice and tips on improving staff wellbeing." , tag: "Case study" , details: {
+            reading_time: "2 minutes" , created_by: "King Charles I School (Secondary)" }) %>
 
-        <div class="govuk-grid-row dfe-width-container">
-          <ul class="resource-card-group">
-
-            <%= render('/partials/resource_card.*', title: "Protect staff time and improve wellbeing" , href: "#{@base_url}/staff-wellbeing/protect-staff-time-and-improve-wellbeing" ,
-              body: "Read tips on using time effectively to improve wellbeing." , tag: "Case study" , details: {
-              reading_time: "2 minutes" , created_by: "West Meon CofE Primary School" }) %>
-
-           <%= render('/partials/resource_card.*', title: "Try ideas to improve staff wellbeing" , href: "#{@base_url}/staff-wellbeing/try-ideas-to-improve-staff-wellbeing" ,
-              body: "Read advice and tips on improving staff wellbeing." , tag: "Case study" , details: {
-              reading_time: "2 minutes" , created_by: "King Charles I School (Secondary)" }) %>
-
-           <%= render('/partials/resource_card.*', title: "Make a list of everything you do to improve wellbeing" , href: "#{@base_url}/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing" ,
-              body: "Read how a school reflects on everything they do to reduce workload and improve wellbeing." , tag: "Case study" , details: {
-              reading_time: "3 minutes" , created_by: "Barr Beacon School (Secondary)" }) %>
-          </ul>
-        </div>
+          <%= render('/partials/resource_card.*', title: "Make a list of everything you do to improve wellbeing" , href: "#{@base_url}/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing" ,
+            body: "Read how a school reflects on everything they do to reduce workload and improve wellbeing." , tag: "Case study" , details: {
+            reading_time: "3 minutes" , created_by: "Barr Beacon School (Secondary)" }) %>
+        </ul>
       </div>
-      <div class="govuk-grid-column-one-third govuk-!-padding-top-0">
+
+      <div class="govuk-grid-column-one-third">
         <hr class="govuk-section-break--thick govuk-!-margin-top-6">
 
-        <div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-          <h2 class="govuk-heading-m">Promote wellbeing and flexible working in your school</h2>
-        </div>
+        <h2 class="govuk-heading-m govuk-!-padding-bottom-6">
+          Promote wellbeing and flexible working in your school
+        </h2>
 
-        <div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-          <p class="govuk-body">
-            <a href="https://www.gov.uk/guidance/education-staff-wellbeing-charter">Education staff wellbeing
-              charter</a>
+        <div class="govuk-!-padding-bottom-6">
+          <p>
+            <a href="https://www.gov.uk/guidance/education-staff-wellbeing-charter">
+              Education staff wellbeing charter
+            </a>
           </p>
-          <p class="govuk-body">
-            <a href="https://www.gov.uk/guidance/get-help-with-flexible-working-in-schools">Flexible working toolkit</a>
+          <p>
+            <a href="https://www.gov.uk/guidance/get-help-with-flexible-working-in-schools">
+              Flexible working toolkit
+            </a>
           </p>
-          <p class="govuk-body">
-            <a href="<%= @base_url %>/staff-wellbeing/supporting-staff-mental-health">Supporting staff mental health in schools</a>
+          <p>
+            <a href="<%= @base_url %>/staff-wellbeing/supporting-staff-mental-health">
+              Supporting staff mental health in schools
+            </a>
           </p>
         </div>
 

--- a/content/staff-wellbeing/academy-trust-workload-agreement.md
+++ b/content/staff-wellbeing/academy-trust-workload-agreement.md
@@ -23,31 +23,27 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        The agreement sets out what teachers and support staff can expect from the academy and the trust they work in, in relation to their workload. It also sets out what leadership should do to manage workload.  
-      </p>
-      <p>
-        Staff at Ascent can expect:
-        <ul>
-          <li>
-            a fair and reasonable workload
-          </li>
-          <li>
-            high quality training and professional development opportunities that meet the needs of individual members of staff
-          </li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    The agreement sets out what teachers and support staff can expect from the academy and the trust they work in, in relation to their workload. It also sets out what leadership should do to manage workload.  
+  </p>
+  <p>
+    Staff at Ascent can expect:
+    <ul>
+      <li>
+        a fair and reasonable workload
+      </li>
+      <li>
+        high quality training and professional development opportunities that meet the needs of individual members of staff
+      </li>
+    </ul>
+  </p>
 </div>
 
 ## Background from Carolyn Morgan, CEO

--- a/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
+++ b/content/staff-wellbeing/communicate-about-wellbeing-to-improve-staff-retention.md
@@ -23,55 +23,51 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        A focus on positive wellbeing had led to:
-        <ul>
-          <li>
-            more effective communication among staff  
-          </li>
-          <li>
-            improved educational outcomes for students 
-          </li>
-          <li>
-            improved career satisfaction which can support retention 
-          </li>
-          <li>
-            lower levels of staff absence
-          </li>
-          <li>
-            increased staff motivation and productivity 
-          </li>
-          <li>
-            staff turnover has reduced from 14% to 6% in the last three years 
-          </li>
-          <li>
-            raised levels of staff morale 
-          </li>
-          <li>
-            staff more able to manage stress  
-          </li>
-          <li>
-            stronger working relationships
-          </li>
-          <li>
-            a team of loyal and committed staff 
-          </li>
-        </ul>
-      </p>
-      <p>
-        Staff have reported that wellbeing and workload has been assessed when leaders introduce new initiatives.
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    A focus on positive wellbeing had led to:
+  </p>
+  <ul>
+    <li>
+      more effective communication among staff  
+    </li>
+    <li>
+      improved educational outcomes for students
+    </li>
+    <li>
+      improved career satisfaction which can support retention
+    </li>
+    <li>
+      lower levels of staff absence
+    </li>
+    <li>
+      increased staff motivation and productivity
+    </li>
+    <li>
+      staff turnover has reduced from 14% to 6% in the last three years
+    </li>
+    <li>
+      raised levels of staff morale
+    </li>
+    <li>
+      staff more able to manage stress  
+    </li>
+    <li>
+      stronger working relationships
+    </li>
+    <li>
+      a team of loyal and committed staff
+    </li>
+  </ul>
+  <p>
+    Staff have reported that wellbeing and workload has been assessed when leaders introduce new initiatives.
+  </p>
 </div>
 
 ## Background from Chris Deller, Headteacher and Laura Fordham, senior leader and Wellbeing Lead

--- a/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
+++ b/content/staff-wellbeing/create-a-school-culture-which-improves-wellbeing.md
@@ -23,26 +23,22 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        By engaging with our staff about workload, we have created a culture of wellbeing and ongoing reflection.  
-      </p>
-      <p>
-        We have relentlessly removed unnecessary tasks or reduced them to their essential components, especially when the justification for doing them was ‘that’s what everyone else does’ or ‘that’s what OFSTED, DfE or some other body want’.  
-      </p>
-      <p>
-        As a result, in our most recent wellbeing survey, 95% of our staff believed they completed their work ‘on time’ and, consequently, over 70% answered ‘very much so’ to the question: do you have a life outside work?  
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    By engaging with our staff about workload, we have created a culture of wellbeing and ongoing reflection.  
+  </p>
+  <p>
+    We have relentlessly removed unnecessary tasks or reduced them to their essential components, especially when the justification for doing them was ‘that’s what everyone else does’ or ‘that’s what OFSTED, DfE or some other body want’.  
+  </p>
+  <p>
+    As a result, in our most recent wellbeing survey, 95% of our staff believed they completed their work ‘on time’ and, consequently, over 70% answered ‘very much so’ to the question: do you have a life outside work?  
+  </p>
 </div>
 
 ## Background from Ben Levinson, Headteacher

--- a/content/staff-wellbeing/establish-a-school-workload-group.md
+++ b/content/staff-wellbeing/establish-a-school-workload-group.md
@@ -23,28 +23,24 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Two examples of outcomes achieved by the school workload group at Baylis Court School were:
-        <ul>
-          <li>
-            the amount of data being gathered was reduced, and therefore the time being spent by staff inputting it without any detrimental impact on pupil outcomes
-          </li> 
-          <li>
-            staff have become more confident in the use of IT and feel they can work more efficiently
-          </li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Two examples of outcomes achieved by the school workload group at Baylis Court School were:
+  </p>
+  <ul>
+    <li>
+      the amount of data being gathered was reduced, and therefore the time being spent by staff inputting it without any detrimental impact on pupil outcomes
+    </li>
+    <li>
+      staff have become more confident in the use of IT and feel they can work more efficiently
+    </li>
+  </ul>
 </div>
 
 ## Background from Richard Kearsey, CEO

--- a/content/staff-wellbeing/establish-a-wellbeing-committee.md
+++ b/content/staff-wellbeing/establish-a-wellbeing-committee.md
@@ -23,35 +23,31 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We established a wellbeing committee who created a report on staff
-        wellbeing which was shared with governors and staff. The report included
-        quantitative data on staff absence rates which we try to benchmark
-        against national data. We use this, as well as qualitative data from our
-        staff wellbeing survey, to give an indication of staff wellbeing to
-        governors.
-      </p>
-      <p>
-        We review the committee terms of reference annually. They were
-        introduced to give clear purpose to the work of the committee so that it
-        did not simply become a ‘talking shop’.
-      </p>
-      <p>
-        All documentation, including minutes of meetings, is freely available to
-        all staff via our intranet. We make this transparent to increase
-        confidence, trust and accountability in what we seek to do.
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We established a wellbeing committee who created a report on staff
+    wellbeing which was shared with governors and staff. The report included
+    quantitative data on staff absence rates which we try to benchmark
+    against national data. We use this, as well as qualitative data from our
+    staff wellbeing survey, to give an indication of staff wellbeing to
+    governors.
+  </p>
+  <p>
+    We review the committee terms of reference annually. They were
+    introduced to give clear purpose to the work of the committee so that it
+    did not simply become a ‘talking shop’.
+  </p>
+  <p>
+    All documentation, including minutes of meetings, is freely available to
+    all staff via our intranet. We make this transparent to increase
+    confidence, trust and accountability in what we seek to do.
+  </p>
 </div>
 
 ## Background from Neil Cully, Headteacher

--- a/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
+++ b/content/staff-wellbeing/make-a-list-of-everything-you-do-to-improve-wellbeing.md
@@ -21,28 +21,25 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Making a list of everything you do to reduce workload and improve wellbeing can help you:
-      </p>
-      <ul>
-        <li>
-          remind yourself of everything you’ve done already 
-        </li>
-        <li>
-          think about what else you could do 
-        </li>
-      </ul>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Making a list of everything you do to reduce workload and improve wellbeing
+    can help you:
+  </p>
+  <ul>
+    <li>
+      remind yourself of everything you’ve done already
+    </li>
+    <li>
+      think about what else you could do
+    </li>
+  </ul>
 </div>
 
 ## Background from David Lowbridge-Ellis, Deputy Headteacher

--- a/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
+++ b/content/staff-wellbeing/protect-staff-time-and-improve-wellbeing.md
@@ -23,23 +23,21 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        As a small school with just 3 members of full-time staff, we had to protect staff time carefully.
-      </p>
-      <p>  
-        We ensured that we had the time to give to the large number of subjects we are responsible for, given the small number of us. 
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    As a small school with just 3 members of full-time staff, we had to protect
+    staff time carefully.
+  </p>
+  <p>  
+    We ensured that we had the time to give to the large number of subjects we
+    are responsible for, given the small number of us.
+  </p>
 </div>
 
 ## Background from Julie Kelly, Headteacher

--- a/content/staff-wellbeing/staff-wellbeing-policy.md
+++ b/content/staff-wellbeing/staff-wellbeing-policy.md
@@ -23,52 +23,53 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        A wellbeing policy helped the Pingle Academy to: 
-      <ul>
-        <li>
-          improve recruitment and retention
-        </li>
-        <li>
-          receive positive Ofsted feedback
-        </li>
-        <li>
-          receive positive feedback from staff on a range of wellbeing themes
-        </li>
-        <li>
-          achieve high engagement from staff with additional lessons or interventions – this is rewarded with time in lieu
-        </li>
-        <li>
-          achieve openness about wellbeing – staff communicate with team leaders and this is supported by a HR follow up
-        </li> 
-        <li>
-          engage collaboratively with professional organisations on academy improvement
-        </li>
-        <li>
-          appoint a lead governor for wellbeing 
-        </li>
-        <li>
-          appoint a mental health lead who works across the trust 
-        </li>
-        <li>
-          get support from the local governing body with its wellbeing plans
-        </li>
-      </ul>
-      </p>
-      <p>
-      'Leaders are considerate of staff and pay careful attention to their workload. One member of staff summed up the views of others in saying, “We look out for each other”.’ (Ofsted report)
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    A wellbeing policy helped the Pingle Academy to:
+  <ul>
+    <li>
+      improve recruitment and retention
+    </li>
+    <li>
+      receive positive Ofsted feedback
+    </li>
+    <li>
+      receive positive feedback from staff on a range of wellbeing themes
+    </li>
+    <li>
+      achieve high engagement from staff with additional lessons or
+      interventions – this is rewarded with time in lieu
+    </li>
+    <li>
+      achieve openness about wellbeing – staff communicate with team leaders and
+      this is supported by a HR follow up
+    </li>
+    <li>
+      engage collaboratively with professional organisations on academy
+      improvement
+    </li>
+    <li>
+      appoint a lead governor for wellbeing
+    </li>
+    <li>
+      appoint a mental health lead who works across the trust
+    </li>
+    <li>
+      get support from the local governing body with its wellbeing plans
+    </li>
+  </ul>
+  </p>
+  <p>
+    'Leaders are considerate of staff and pay careful attention to their
+    workload. One member of staff summed up the views of others in saying,
+    “We look out for each other”.’ (Ofsted report)
+  </p>
 </div>
 
 ## Background from Mary Hall, Vice Principal

--- a/content/staff-wellbeing/staff-wellbeing-statement.md
+++ b/content/staff-wellbeing/staff-wellbeing-statement.md
@@ -23,33 +23,30 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Our united approach creates: 
-        <ul>
-          <li>
-            a sense of belonging
-          </li>
-          <li> 
-            a culture that is based upon our core wellbeing principles 
-          </li>
-          <li>
-            an environment that recognises skills and encourages personal development
-          </li>
-          <li>
-            an environment whereby employees feel they are listened to 
-          </li>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Our united approach creates:
+  </p>
+  <ul>
+    <li>
+      a sense of belonging
+    </li>
+    <li>
+      a culture that is based upon our core wellbeing principles
+    </li>
+    <li>
+      an environment that recognises skills and encourages personal development
+    </li>
+    <li>
+      an environment whereby employees feel they are listened to
+    </li>
+  </ul>
 </div>
 
 ## Background from Rachel Boyall, HR Manager

--- a/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
+++ b/content/staff-wellbeing/try-ideas-to-improve-staff-wellbeing.md
@@ -23,31 +23,30 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We made these changes to enable every teacher to become highly effective by:
-        <ul>
-          <li>
-            ensuring every teacher has time to focus on what is important - planning, teaching and feedback
-          </li>
-          <li>
-            believing in simplicity, always taking the shortest route and aiming for maximum impact on student learning with minimal workload for staff
-          </li>
-          <li>
-            continuously reviewing and evaluating our systems in order to support all staff to achieve a healthy work life balance
-          </li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We made these changes to enable every teacher to become highly effective by:
+  </p>
+  <ul>
+    <li>
+      ensuring every teacher has time to focus on what is important - planning,
+      teaching and feedback
+    </li>
+    <li>
+      believing in simplicity, always taking the shortest route and aiming for
+      maximum impact on student learning with minimal workload for staff
+    </li>
+    <li>
+      continuously reviewing and evaluating our systems in order to support all
+      staff to achieve a healthy work life balance
+    </li>
+  </ul>
 </div>
 
 ## Background from Ruth Allen, Deputy Headteacher

--- a/content/staff-wellbeing/wellbeing-and-workload-charter.md
+++ b/content/staff-wellbeing/wellbeing-and-workload-charter.md
@@ -23,55 +23,51 @@ colour: blue
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        A focus on positive wellbeing had led to:
-        <ul>
-          <li>
-            more effective communication among staff  
-          </li>
-          <li>
-            improved educational outcomes for students 
-          </li>
-          <li>
-            improved career satisfaction which can support retention 
-          </li>
-          <li>
-            lower levels of staff absence
-          </li>
-          <li>
-            increased staff motivation and productivity 
-          </li>
-          <li>
-            staff turnover has reduced from 14% to 6% in the last three years 
-          </li>
-          <li>
-            raised levels of staff morale 
-          </li>
-          <li>
-            staff more able to manage stress  
-          </li>
-          <li>
-            stronger working relationships
-          </li>
-          <li>
-            a team of loyal and committed staff 
-          </li>
-        </ul>
-      </p>
-      <p>
-        Staff have reported that wellbeing and workload has been assessed when leaders introduce new initiatives.
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    A focus on positive wellbeing had led to:
+  </p>
+  <ul>
+    <li>
+      more effective communication among staff  
+    </li>
+    <li>
+      improved educational outcomes for students
+    </li>
+    <li>
+      improved career satisfaction which can support retention
+    </li>
+    <li>
+      lower levels of staff absence
+    </li>
+    <li>
+      increased staff motivation and productivity
+    </li>
+    <li>
+      staff turnover has reduced from 14% to 6% in the last three years
+    </li>
+    <li>
+      raised levels of staff morale
+    </li>
+    <li>
+      staff more able to manage stress  
+    </li>
+    <li>
+      stronger working relationships
+    </li>
+    <li>
+      a team of loyal and committed staff
+    </li>
+  </ul>
+  <p>
+    Staff have reported that wellbeing and workload has been assessed when leaders introduce new initiatives.
+  </p>
 </div>
 
 ## Background from Chris Deller, Headteacher and Laura Fordham, senior leader and Wellbeing Lead

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -7,12 +7,12 @@ title: Workload reduction toolkit
     <div class="govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-0">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-4">Workload reduction toolkit</h1>
-        <p class="govuk-body">
+        <p>
           Access workload reduction resources produced by school leaders, for
           school leaders. Learn how they addressed workload issues and save time
           when addressing those issues in your school.
         </p>
-        <p class="govuk-body govuk-!-font-weight-bold">
+        <p class="govuk-!-font-weight-bold">
           <a href="<%= @base_url %>/workload-reduction-toolkit/how-the-toolkit-was-made">
             Learn how the toolkit was made and tested
           </a>
@@ -28,11 +28,13 @@ title: Workload reduction toolkit
 
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container">
-    <div class="govuk-grid-row govuk-width-container">
-      <h2 class="govuk-heading-m">Use the toolkit</h2>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m">Use the toolkit</h2>
+      </div>
     </div>
 
-    <ul class="govuk-grid-row card-group">
+    <ul class="govuk-grid-row card-group govuk-!-margin-bottom-9">
       <li class="govuk-grid-column-one-third card-group__item">
         <%= render('/partials/tile.*', title: "Identify workload issues",
           body: "Identify workload issues and prioritise where to act",
@@ -57,17 +59,12 @@ title: Workload reduction toolkit
         ) %>
       </li>
     </ul>
-  </div>
-</div>
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  </div>
-</div>
-
-<div class="dfe-width-container govuk-grid-row govuk-!-margin-top-7">
-  <div class="govuk-grid-column-full">
-    <%= render '/partials/feedback.*' %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <hr class="govuk-section-break--visible govuk-!-margin-bottom-9">
+        <%= render '/partials/feedback.*' %>
+      </div>
+    </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -34,7 +34,7 @@ title: Workload reduction toolkit
       </div>
     </div>
 
-    <ul class="govuk-grid-row card-group govuk-!-margin-bottom-9">
+    <ul class="govuk-grid-row card-group govuk-!-margin-bottom-6">
       <li class="govuk-grid-column-one-third card-group__item">
         <%= render('/partials/tile.*', title: "Identify workload issues",
           body: "Identify workload issues and prioritise where to act",

--- a/content/workload-reduction-toolkit/address-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues.html.erb
@@ -3,36 +3,37 @@ title: Address workload issues
 ---
 
 <div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row govuk-!-padding-top-6">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Address workload issues</h1>
-    </div>
-  </div>
-
-  <div class="dfe-width-container govuk-grid-row govuk-!-padding-bottom-9">
-    <div class="govuk-grid-column-one-half">
-      <p class="govuk-body">
-        This section of the toolkit has groups of resources to address specific
-        workload issues.
-      </p>
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row govuk-!-padding-bottom-9">
+      <div class="govuk-grid-column-one-half">
+        <h1 class="govuk-heading-l">Address workload issues</h1>
+        <p>
+          This section of the toolkit has groups of resources to address specific
+          workload issues.
+        </p>
+      </div>
     </div>
   </div>
 
   <div class="content__section--grey">
     <div class="dfe-width-container">
-      <ul class="govuk-grid-row card-group">
-        <%= render('/partials/icon_card.*', text: "Data management", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/data-management")%>
-        <%= render('/partials/icon_card.*', text: "Feedback and marking", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/feedback-and-marking")%>
-        <%= render('/partials/icon_card.*', text: "Curriculum planning and delivery", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery")%>
-        <%= render('/partials/icon_card.*', text: "Behaviour management", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/behaviour-management")%>
-        <%= render('/partials/icon_card.*', text: "Communications", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/communications")%>
-      </ul>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <ul class="card-group">
+            <%= render('/partials/icon_card.*', text: "Data management", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/data-management")%>
+            <%= render('/partials/icon_card.*', text: "Feedback and marking", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/feedback-and-marking")%>
+            <%= render('/partials/icon_card.*', text: "Curriculum planning and delivery", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery")%>
+            <%= render('/partials/icon_card.*', text: "Behaviour management", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/behaviour-management")%>
+            <%= render('/partials/icon_card.*', text: "Communications", href: "#{@base_url}/workload-reduction-toolkit/address-workload-issues/communications")%>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="dfe-width-container govuk-grid-row govuk-!-margin-top-7">
-  <div class="govuk-grid-column-full">
-    <%= render '/partials/feedback.*' %>
+  <div class="dfe-width-container govuk-grid-row govuk-!-margin-top-9">
+    <div class="govuk-grid-column-full">
+      <%= render '/partials/feedback.*' %>
+    </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/review-and-streamline-behaviour-management.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/review-and-streamline-behaviour-management.md
@@ -15,34 +15,30 @@ The presentation includes:
 - questions for discussion and a structured discussion template
 - next steps, reviewing and updating the behaviour policy
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the presentation
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/behaviour-management--review-and-streamline-behaviour-management.jpg" alt="Review and streamline behaviour management" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.pptx">
-            Download Microsoft PowerPoint
-         </a>
-         <p>
-           PPTX, 181KB, 7 slides
-         </p>
-         <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.odp">
-           Download OpenDocument Presentation
-         </a>
-         <p>
-           ODP, 322KB, 7 slides
-         </p>
-       </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the presentation
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/behaviour-management--review-and-streamline-behaviour-management.jpg" alt="Review and streamline behaviour management" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.pptx">
+        Download Microsoft PowerPoint
+      </a>
+      <p>
+        PPTX, 181KB, 7 slides
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.odp">
+        Download OpenDocument Presentation
+      </a>
+      <p>
+        ODP, 322KB, 7 slides
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-out-a-clear-and-consistent-approach-to-behaviour-management.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-out-a-clear-and-consistent-approach-to-behaviour-management.md
@@ -22,25 +22,21 @@ title: Set out a clear and consistent approach to behaviour management
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-         Setting out a clear and consistent approach to behaviour management can
-         reduce workload.
-      </p>
-      <p>
-        It enables teachers to simply teach, rather than spend time dealing with
-        low level disruption.
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+      Setting out a clear and consistent approach to behaviour management can
+      reduce workload.
+  </p>
+  <p>
+    It enables teachers to simply teach, rather than spend time dealing with
+    low level disruption.
+  </p>
 </div>
 
 ## Background from Chris Gibson, Deputy Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-up-a-centralised-system-to-record-monitor-and-reward-pupil-behaviour.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/set-up-a-centralised-system-to-record-monitor-and-reward-pupil-behaviour.md
@@ -22,46 +22,38 @@ title: Set up a centralised system to record, monitor and reward pupil behaviour
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        A centralised system to record pupil behaviour can help you:
-      </p>
-      <p>
-        <ul>
-          <li>
-            identify issues with behaviour
-          </li>
-          <li>
-            intervene where necessary
-          </li>
-          <li>
-            reward good behaviour
-          </li>
-        </ul>
-      </p>
-      <p>
-        It also saves time and reduces paperwork, letting you:
-      </p>
-      <p>
-        <ul>
-          <li>
-            record information straight away
-          </li>
-          <li>
-            analyse behaviour regularly
-          </li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    A centralised system to record pupil behaviour can help you:
+  </p>
+  <ul>
+    <li>
+      identify issues with behaviour
+    </li>
+    <li>
+      intervene where necessary
+    </li>
+    <li>
+      reward good behaviour
+    </li>
+  </ul>
+  <p>
+    It also saves time and reduces paperwork, letting you:
+  </p>
+  <ul>
+    <li>
+      record information straight away
+    </li>
+    <li>
+      analyse behaviour regularly
+    </li>
+  </ul>
 </div>
 
 ## Background from Jason Ashley, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/try-ideas-to-manage-behaviour-management-workload.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/try-ideas-to-manage-behaviour-management-workload.md
@@ -22,38 +22,34 @@ title: Try ideas to manage behaviour management workload
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We made these changes to enable every teacher to become highly
-        effective by:
-      </p>
-      <p>
-        <ul>
-          <li>
-            ensuring every teacher has time to focus on what is important -
-            planning, teaching and feedback
-          </li>
-          <li>
-            believing in simplicity, always taking the shortest route and aiming
-            for maximum impact on student learning with minimal workload for
-            staff
-          </li>
-          <li>
-            continuously reviewing and evaluating our systems in order to
-            support all staff to achieve a healthy work life balance
-          </li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We made these changes to enable every teacher to become highly
+    effective by:
+  </p>
+  <p>
+    <ul>
+      <li>
+        ensuring every teacher has time to focus on what is important -
+        planning, teaching and feedback
+      </li>
+      <li>
+        believing in simplicity, always taking the shortest route and aiming
+        for maximum impact on student learning with minimal workload for
+        staff
+      </li>
+      <li>
+        continuously reviewing and evaluating our systems in order to
+        support all staff to achieve a healthy work life balance
+      </li>
+    </ul>
+  </p>
 </div>
 
 ## Background from Ruth Allen, Deputy Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/parental-communications-policy.md
@@ -22,36 +22,30 @@ title: Parental communications policy
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-         Our parental communications policy has led to:
-      </p>
-      <p>
-        <ul>
-         <li>
-            a reduction in the demands to respond to parental emails in the
-            evenings and weekends, so that work and home boundaries are clearer
-         </li>
-         <li>
-            parents and carers better understand the context in which teachers
-            are working, and can modify their expectations of an immediate reply
-         </li>
-         <li>
-            communication is distributed and directed more appropriately across
-            the staff team
-         </li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+      Our parental communications policy has led to:
+  </p>
+  <ul>
+    <li>
+      a reduction in the demands to respond to parental emails in the
+      evenings and weekends, so that work and home boundaries are clearer
+    </li>
+    <li>
+      parents and carers better understand the context in which teachers
+      are working, and can modify their expectations of an immediate reply
+    </li>
+    <li>
+      communication is distributed and directed more appropriately across
+      the staff team
+    </li>
+  </ul>
 </div>
 
 ## Background from Michael Antram, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
@@ -5,170 +5,162 @@ title: Review and streamline communications
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container govuk-grid-row two-column-page content-section--purple">
     <div class="govuk-grid-column-two-thirds">
-      <div class="dfe-width-container govuk-grid-row">
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline communications</h1>
-        <div class="dfe-width-container govuk-grid-row govuk-!-margin-bottom-7">
-          <strong class="govuk-tag">Presentation</strong>
-        </div>
-        <div class="dfe-width-container govuk-grid-row">
-          <p>
-            Use this presentation in a staff meeting or INSET day to review and
-            streamline your internal and external communication processes.
-          </p>
-          <p>
-            The presentation includes:
-          <ul>
-            <li>
-              background and context about managing communications
-            </li>
-            <li>
-              a discussion to reflect on why we communicate and whether the
-              processes should be updated, streamlined or stopped altogether
-            </li>
-            <li>
-              a reflection on why we communicate
-            </li>
-            <li>
-              a discussion on whether current communication processes should be
-              updated, streamlined or stopped altogether
-            </li>
-          </ul>
-          </p>
-        </div>
-      </div>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline communications</h1>
 
-      <div class="govuk-grid-row dfe-width-container">
-        <div class="govuk-grid-column-full">
-          <div class="info-box">
-            <div class="info-box__corner">
-              <img src="/assets/images/download-icon.svg" alt="Download icon">
-            </div>
-            <h2 class="govuk-heading-m">
-              Download the presentation
-            </h2>
-            <div class="govuk-grid-row info-box__download-content">
-              <div class="govuk-grid-column-one-half">
-                <img src="/assets/images/communications--review-and-streamline-communications.jpg" alt="Review and streamline communications" class="dfe-file-preview-image">
-              </div>
-              <div class="govuk-grid-column-one-half">
-                <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.pptx">
-                  Download Microsoft PowerPoint
-                </a>
-                <p>
-                  PPTX, 101KB, 6 slides
-                </p>
-                <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
-                  Download OpenDocument Presentation
-                </a>
-                <p>
-                  ODP, 301KB, 6 slides
-                </p>
-              </div>
-            </div>
+      <p class="govuk-!-margin-bottom-7">
+        <strong class="govuk-tag">Presentation</strong>
+      </p>
+      
+      <p>
+        Use this presentation in a staff meeting or INSET day to review and
+        streamline your internal and external communication processes.
+      </p>
+
+      <p>
+        The presentation includes:
+      </p>
+
+      <ul>
+        <li>
+          background and context about managing communications
+        </li>
+        <li>
+          a discussion to reflect on why we communicate and whether the
+          processes should be updated, streamlined or stopped altogether
+        </li>
+        <li>
+          a reflection on why we communicate
+        </li>
+        <li>
+          a discussion on whether current communication processes should be
+          updated, streamlined or stopped altogether
+        </li>
+      </ul>
+
+      <div class="info-box">
+        <div class="info-box__corner">
+          <img src="/assets/images/download-icon.svg" alt="Download icon">
+        </div>
+        <h2 class="govuk-heading-m">
+          Download the presentation
+        </h2>
+        <div class="govuk-grid-row info-box__download-content">
+          <div class="govuk-grid-column-one-half">
+            <img src="/assets/images/communications--review-and-streamline-communications.jpg" alt="Review and streamline communications" class="dfe-file-preview-image">
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.pptx">
+              Download Microsoft PowerPoint
+            </a>
+            <p>
+              PPTX, 101KB, 6 slides
+            </p>
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
+              Download OpenDocument Presentation
+            </a>
+            <p>
+              ODP, 301KB, 6 slides
+            </p>
           </div>
         </div>
       </div>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
-          Audience
-        </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+        Audience
+      </h2>
 
-        <p>
-          The presentation and facilitator notes will support senior leadership
-          teams to run a staff meeting with the whole school, teams or
-          departments.
-        </p>
-      </div>
+      <p>
+        The presentation and facilitator notes will support senior leadership
+        teams to run a staff meeting with the whole school, teams or
+        departments.
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          Presentation length
-        </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Presentation length
+      </h2>
 
-        <p>
-          The presentation should take 1 hour. You should also allocate time for
-          the facilitator to prepare the session for use in your school.
-        </p>
-      </div>
+      <p>
+        The presentation should take 1 hour. You should also allocate time for
+        the facilitator to prepare the session for use in your school.
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          How to run with your staff
-        </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        How to run with your staff
+      </h2>
 
-        <p>
-          You can run the exercises in a staff meeting or they can be completed
-          individually or by teams ahead of the meeting.
-        </p>
-        <p>
-          Supporting resources can be printed or shared digitally and they are
-          editable. For example, you could adapt the table to suit the needs of
-          the staff group, by populating the 'how' column or changing the 'who
-          we communicate with' column. If the group is largely teachers, they
-          could complete the table together to consider how, as teachers, they
-          communicate with other staff, each other, parents or governors.
-        </p>
-        <p>
-          You could address internal and external communications separately or
-          choose one to focus on for this exercise.
-        </p>
-        <p>
-          Senior leadership teams are likely to want to oversee the process.
-          You could consider if it is more appropriate for another member of
-          staff to facilitate the session and lead on follow-up. You could also
-          consider asking somebody independent to facilitate the workshop to
-          free up time to take part.
-        </p>
-        <p>
-          Provide a supportive environment for open and honest professional
-          dialogue.
-        </p>
-      </div>
+      <p>
+        You can run the exercises in a staff meeting or they can be completed
+        individually or by teams ahead of the meeting.
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          Supporting resources
-        </h2>
+      <p>
+        Supporting resources can be printed or shared digitally and they are
+        editable. For example, you could adapt the table to suit the needs of
+        the staff group, by populating the 'how' column or changing the 'who
+        we communicate with' column. If the group is largely teachers, they
+        could complete the table together to consider how, as teachers, they
+        communicate with other staff, each other, parents or governors.
+      </p>
 
-        <ul class="resource-card-group">
-          <%= render('/partials/resource_card_with_image.*', title: "How we communicate" ,
-            body: "A template to help you explore how effective and efficient your communications are." ,
-            image_url: "/assets/images/communications--how-we-communicate.jpg" ,
-            tag: "Template" , download_links: [
-              {
-                href: "#{@base_url}/assets/files/Review_school_communications.docx",
-                text: "Download Microsoft Word Document",
-                details: "DOCX, 25KB, 1 page",
-              },
-              {
-                href: "#{@base_url}/assets/files/Review_school_communications.odt",
-                text: "Download OpenDocument Text",
-                details: "ODP, 8KB, 1 page",
-              },
-            ]
-          ) %>
+      <p>
+        You could address internal and external communications separately or
+        choose one to focus on for this exercise.
+      </p>
 
-          <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
-            body: "A template to help you prioritise what to address first." ,
-            image_url: "/assets/images/communications--impact-graph.jpg" ,
-            tag: "Template" , download_links: [
-              {
-                href: "#{@base_url}/assets/files/Impact graph.docx",
-                text: "Download Microsoft Word Document",
-                details: "DOCX, 31KB, 1 page",
-              },
-              {
-                href: "#{@base_url}/assets/files/Impact graph.odt",
-                text: "Download OpenDocument Text",
-                details: "ODP, 6KB, 1 page",
-              },
-            ]
-          ) %>
-        </ul>
-      </div>
+      <p>
+        Senior leadership teams are likely to want to oversee the process.
+        You could consider if it is more appropriate for another member of
+        staff to facilitate the session and lead on follow-up. You could also
+        consider asking somebody independent to facilitate the workshop to
+        free up time to take part.
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row govuk-!-margin-top-6">
+      <p>
+        Provide a supportive environment for open and honest professional
+        dialogue.
+      </p>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Supporting resources
+      </h2>
+
+      <ul class="resource-card-group">
+        <%= render('/partials/resource_card_with_image.*', title: "How we communicate" ,
+          body: "A template to help you explore how effective and efficient your communications are." ,
+          image_url: "/assets/images/communications--how-we-communicate.jpg" ,
+          tag: "Template" , download_links: [
+            {
+              href: "#{@base_url}/assets/files/Review_school_communications.docx",
+              text: "Download Microsoft Word Document",
+              details: "DOCX, 25KB, 1 page",
+            },
+            {
+              href: "#{@base_url}/assets/files/Review_school_communications.odt",
+              text: "Download OpenDocument Text",
+              details: "ODP, 8KB, 1 page",
+            },
+          ]
+        ) %>
+
+        <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
+          body: "A template to help you prioritise what to address first." ,
+          image_url: "/assets/images/communications--impact-graph.jpg" ,
+          tag: "Template" , download_links: [
+            {
+              href: "#{@base_url}/assets/files/Impact graph.docx",
+              text: "Download Microsoft Word Document",
+              details: "DOCX, 31KB, 1 page",
+            },
+            {
+              href: "#{@base_url}/assets/files/Impact graph.odt",
+              text: "Download OpenDocument Text",
+              details: "ODP, 6KB, 1 page",
+            },
+          ]
+        ) %>
+      </ul>
+
+      <div class="govuk-!-margin-top-8">
         <%= render '/partials/share_this_resource.*' %>
       </div>
     </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/school-email-protocol.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/school-email-protocol.md
@@ -22,26 +22,25 @@ title: School email protocol
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        As a result of this school email protocol the: 
-      </p>
-      <p>
-        <ul>
-          <li>volume of emails we send has reduced</li>
-          <li>use of centralised bulletins has gathered important general communications into one place</li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    As a result of this school email protocol the:
+  </p>
+  <ul>
+    <li>
+      volume of emails we send has reduced
+    </li>
+    <li>
+      use of centralised bulletins has gathered important general communications
+      into one place
+    </li>
+  </ul>
 </div>
 
 ## Background from Michael Antram, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/streamline-internal-school-communications.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/streamline-internal-school-communications.md
@@ -22,32 +22,32 @@ title: Streamline internal school communications
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        The total number of minutes spent on communication in school was collated both pre and post intervention. There was an 18% reduction in the number of minutes spent per week.
-      </p>
-      <p>
-        Staff surveys at the beginning and end of the project showed that staff perceptions of communications had improved in four out of five areas:
-      </p>
-      <ul>
-        <li>efficiency</li>
-        <li>less time wasted</li>
-        <li>being kept informed</li>
-        <li>sufficient notice of changes</li>
-      </ul>
-      <p>
-        There was no change in teacher perception on responding to emails outside of work.
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    The total number of minutes spent on communication in school was collated
+    both pre and post intervention. There was an 18% reduction in the number of
+    minutes spent per week.
+  </p>
+  <p>
+    Staff surveys at the beginning and end of the project showed that staff
+    perceptions of communications had improved in four out of five areas:
+  </p>
+  <ul>
+    <li>efficiency</li>
+    <li>less time wasted</li>
+    <li>being kept informed</li>
+    <li>sufficient notice of changes</li>
+  </ul>
+  <p>
+    There was no change in teacher perception on responding to emails outside of
+    work.
+  </p>
 </div>
 
 ## Background from Jane Robinson, Head of School

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/switch-to-online-parents-evenings.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/switch-to-online-parents-evenings.md
@@ -22,35 +22,31 @@ title: Switch to online parents’ evenings
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-       There were far more benefits to the online system than drawbacks. It led
-       to higher attendance from parents and the majority of stakeholders when questioned were keen to keep it post-pandemic.
-      </p>
-      <p>
-         The following two quotes are from classroom teachers.
-      </p>
-      <p>
-         “I feel very strongly that it is much less stressful for all parties.
-         It ensures all staff/parents stick to time meaning all those with an
-         appointment do get a fair equal opportunity to talk. So much time is
-         saved by not moving around so that 5 minutes is usually more than
-         sufficient time for productive discussion.”  
-      </p>
-      <p>
-         “This really helped with the timings and engagement of parents, and it
-         gives more flexibility as a parent of young children myself.”
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    There were far more benefits to the online system than drawbacks. It led
+    to higher attendance from parents and the majority of stakeholders when questioned were keen to keep it post-pandemic.
+  </p>
+  <p>
+      The following two quotes are from classroom teachers.
+  </p>
+  <p>
+      “I feel very strongly that it is much less stressful for all parties.
+      It ensures all staff/parents stick to time meaning all those with an
+      appointment do get a fair equal opportunity to talk. So much time is
+      saved by not moving around so that 5 minutes is usually more than
+      sufficient time for productive discussion.”
+  </p>
+  <p>
+      “This really helped with the timings and engagement of parents, and it
+      gives more flexibility as a parent of young children myself.”
+  </p>
 </div>
 
 ## Background from Claire Willis, Assistant Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/change-lesson-observations-to-class-visits.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/change-lesson-observations-to-class-visits.md
@@ -22,49 +22,48 @@ title: Change lesson observations to class visits
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Changing lesson observations to more informal class visits resulted in:
-      </p>
-      <ul>
-        <li>
-          reduced workload in terms of planning and preparation for leaders and teachers
-        </li>
-        <li>
-          a truer and more authentic reflection of what happens in classrooms 
-        </li>
-        <li>
-          less stress for teachers with focused feedback 
-        </li>
-        <li>
-          the process being valued by teachers and a perception it’s not ‘being done’ to them
-        </li>
-        <li>
-          development of a genuine ‘open door’ culture 
-        </li>
-        <li>
-          an effective improvement in quality of education 
-        </li>
-        <li>
-          notes from lesson visits feeding into teacher’s appraisals alongside other evidence 
-        </li>
-        <li>
-          opportunities for leaders to learn from each other  
-        </li>
-        <li>
-          better support for professional development
-        </li>
-      </ul>      
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Changing lesson observations to more informal class visits resulted in:
+  </p>
+  <ul>
+    <li>
+      reduced workload in terms of planning and preparation for leaders and
+      teachers
+    </li>
+    <li>
+      a truer and more authentic reflection of what happens in classrooms
+    </li>
+    <li>
+      less stress for teachers with focused feedback
+    </li>
+    <li>
+      the process being valued by teachers and a perception it’s not
+      ‘being done’ to them
+    </li>
+    <li>
+      development of a genuine ‘open door’ culture
+    </li>
+    <li>
+      an effective improvement in quality of education
+    </li>
+    <li>
+      notes from lesson visits feeding into teacher’s appraisals alongside other
+      evidence
+    </li>
+    <li>
+      opportunities for leaders to learn from each other  
+    </li>
+    <li>
+      better support for professional development
+    </li>
+  </ul>
 </div>
 
 ## Background from Jo Summerfield, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/develop-a-culture-of-support-and-staff-development.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/develop-a-culture-of-support-and-staff-development.md
@@ -22,26 +22,33 @@ title: Develop a culture of support and staff development
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Investing time and support to help everyone develop pays off. This policy resulted in paperwork reducing greatly and a positive culture developing.
-      </p>
-       <p>
-         A year 5 teacher who had been teaching for six years stated:
-       </p>
-      <p>
-        “When I first arrived at the school the paperwork was intense. We had regular lesson observations, we were required to annotate daily planning, update assessment scoring systems, conduct book scrutinies, complete evidence trails and do lots of marking in books. Over the years the school has slowly moved away from, what at times seemed a box-ticking culture, to remove the burden of paperwork away from the teachers so they can focus on what makes a difference - working with the children. Now our approach to assessment and monitoring is much more informal and involves daily assessment in class and informal chats with our SLT and wider team. As a team we communicate daily and make changes based on what we see each day. This approach is having a real impact in class.” 
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Investing time and support to help everyone develop pays off. This policy
+    resulted in paperwork reducing greatly and a positive culture developing.
+  </p>
+  <p>
+    A year 5 teacher who had been teaching for six years stated:
+  </p>
+  <p>
+    “When I first arrived at the school the paperwork was intense. We had
+    regular lesson observations, we were required to annotate daily planning,
+    update assessment scoring systems, conduct book scrutinies, complete
+    evidence trails and do lots of marking in books. Over the years the school
+    has slowly moved away from, what at times seemed a box-ticking culture, to
+    remove the burden of paperwork away from the teachers so they can focus on
+    what makes a difference - working with the children. Now our approach to
+    assessment and monitoring is much more informal and involves daily
+    assessment in class and informal chats with our SLT and wider team. As a
+    team we communicate daily and make changes based on what we see each day.
+    This approach is having a real impact in class.”
+  </p>
 </div>
 
 ## Background from Ben Levinson, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/review-and-streamline-lesson-planning.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/review-and-streamline-lesson-planning.md
@@ -15,36 +15,30 @@ The presentation includes:
 - a discussion on how planning can best improve the quality of teaching and learning
 - next steps
 
-<div class="dfe-width-container govuk-grid-row">
-  <div class="govuk-grid-row dfe-width-container">
-    <div class="govuk-grid-column-full">
-      <div class="info-box">
-        <div class="info-box__corner">
-          <img src="/assets/images/download-icon.svg" alt="Download icon">
-        </div>
-        <h2 class="govuk-heading-m">
-          Download the presentation
-        </h2>
-        <div class="govuk-grid-row info-box__download-content">
-          <div class="govuk-grid-column-one-half">
-            <img src="/assets/images/curriculum-planning-and-delivery--review-and-streamline-lesson-planning.jpg" alt="Review and streamline lesson planning" class="dfe-file-preview-image">
-          </div>
-          <div class="govuk-grid-column-one-half">
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.pptx">
-              Download Microsoft PowerPoint
-            </a>
-            <p>
-              PPTX, 114KB, 9 slides
-            </p>
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.odp">
-              Download OpenDocument Presentation
-            </a>
-            <p>
-              ODP, 252KB, 9 slides
-            </p>
-          </div>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the presentation
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/curriculum-planning-and-delivery--review-and-streamline-lesson-planning.jpg" alt="Review and streamline lesson planning" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.pptx">
+        Download Microsoft PowerPoint
+      </a>
+      <p>
+        PPTX, 114KB, 9 slides
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.odp">
+        Download OpenDocument Presentation
+      </a>
+      <p>
+        ODP, 252KB, 9 slides
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/try-ideas-to-manage-planning.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/try-ideas-to-manage-planning.md
@@ -22,32 +22,29 @@ title: Try ideas to manage planning and curriculum workload
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We made these changes to enable every teacher to become highly effective by:
-      </p>
-      <ul>
-        <li>
-          ensuring every teacher has time to focus on what is important - planning, teaching and feedback
-        </li>
-        <li>
-          believing in simplicity, always taking the shortest route and aiming for maximum impact on student learning with minimal workload for staff 
-        </li>
-        <li>
-          continuously reviewing and evaluating our systems in order to support all staff to achieve a healthy work life balance
-        </li>
-     </ul> 
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We made these changes to enable every teacher to become highly effective by:
+  </p>
+  <ul>
+    <li>
+      ensuring every teacher has time to focus on what is important - planning, teaching and feedback
+    </li>
+    <li>
+      believing in simplicity, always taking the shortest route and aiming for
+      maximum impact on student learning with minimal workload for staff
+    </li>
+    <li>
+      continuously reviewing and evaluating our systems in order to support all
+      staff to achieve a healthy work life balance
+    </li>
+  </ul>
 </div>
 
 ## Background from Ruth Allen, Deputy Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/use-time-effectively.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/use-time-effectively.md
@@ -22,24 +22,20 @@ title: Use time effectively and work together when planning your curriculum
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We found ways to use time effectively when planning our curriculum, such as making the most of published and online schemes.
-      </p>
-      <p>
-        We also saved time on curriculum planning by working together. 
-      </p>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We found ways to use time effectively when planning our curriculum, such as
+    making the most of published and online schemes.
+  </p>
+  <p>
+    We also saved time on curriculum planning by working together.
+  </p>
 </div>
 
 ## Background from Julie Kelly, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
@@ -5,139 +5,136 @@ title: Review and streamline data management
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container govuk-grid-row two-column-page content-section--purple">
     <div class="govuk-grid-column-two-thirds">
-      <div class="dfe-width-container govuk-grid-row">
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline data management</h1>
-        <div class="dfe-width-container govuk-grid-row govuk-!-margin-bottom-7">
-          <strong class="govuk-tag">Presentation</strong>
-        </div>
-        <div class="dfe-width-container govuk-grid-row">
-          <p>
-            Use this presentation in a staff meeting or INSET day to review and streamline your data management processes. 
-          </p>
-          <p>
-            The presentation includes:
-          <ul>
-            <li>
-              background and context
-            </li>
-            <li>
-              a discussion to understand better why data is collected and how collections can be streamlined or stopped altogether
-            </li>
-            <li>
-              a further discussion to decide what data is collected and not collected in future
-            </li>
-          </ul>
-          </p>
-        </div>
-      </div>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline data management</h1>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <div class="govuk-grid-row dfe-width-container">
-          <div class="govuk-grid-column-full">
-            <div class="info-box">
-              <div class="info-box__corner">
-                <img src="/assets/images/download-icon.svg" alt="Download icon">
-              </div>
-              <h2 class="govuk-heading-m">
-                Download the presentation
-              </h2>
-              <div class="govuk-grid-row info-box__download-content">
-                <div class="govuk-grid-column-one-half">
-                  <img src="/assets/images/data-management--review-and-streamline-data-management.jpg" alt="Review and streamline data management" class="dfe-file-preview-image">
-                </div>
-                <div class="govuk-grid-column-one-half">
-                 <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.pptx">
-                   Download Microsoft PowerPoint
-                 </a>
-                 <p>
-                   PPTX, 114KB, 9 slides
-                 </p>
-                 <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.odp">
-                   Download OpenDocument Presentation
-                 </a>
-                 <p>
-                  ODP, 119KB, 9 slides
-                </p>
-                </div>
-              </div>
-            </div>
+      <p class="govuk-!-margin-bottom-7">
+        <strong class="govuk-tag">Presentation</strong>
+      </p>
+
+      <p>
+        Use this presentation in a staff meeting or INSET day to review and
+        streamline your data management processes.
+      </p>
+
+      <p>
+        The presentation includes:
+      </p>
+
+      <ul>
+        <li>
+          background and context
+        </li>
+        <li>
+          a discussion to understand better why data is collected and how
+          collections can be streamlined or stopped altogether
+        </li>
+        <li>
+          a further discussion to decide what data is collected and not
+          collected in future
+        </li>
+      </ul>
+
+      <div class="info-box">
+        <div class="info-box__corner">
+          <img src="/assets/images/download-icon.svg" alt="Download icon">
+        </div>
+        <h2 class="govuk-heading-m">
+          Download the presentation
+        </h2>
+        <div class="govuk-grid-row info-box__download-content">
+          <div class="govuk-grid-column-one-half">
+            <img src="/assets/images/data-management--review-and-streamline-data-management.jpg" alt="Review and streamline data management" class="dfe-file-preview-image">
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.pptx">
+              Download Microsoft PowerPoint
+            </a>
+            <p>
+              PPTX, 114KB, 9 slides
+            </p>
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.odp">
+              Download OpenDocument Presentation
+            </a>
+            <p>
+              ODP, 119KB, 9 slides
+          </p>
           </div>
         </div>
       </div>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
-          Audience
-        </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+        Audience
+      </h2>
 
-        <p>
-          The presentation has been provided for senior leadership teams to run with the whole school, teams or departments.
-        </p>
-        <p>
-          It could also be an exercise just for senior leadership, with the results shared and discussed with staff.
-        </p>
-      </div>
+      <p>
+        The presentation has been provided for senior leadership teams to run
+        with the whole school, teams or departments.  
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          Presentation length
-        </h2>
+      <p>
+        It could also be an exercise just for senior leadership, with the
+        results shared and discussed with staff. 
+      </p>
 
-        <p>
-          The presentation should take 1 hour. You should also allocate time for
-          the facilitator to prepare the session for use in your school.
-        </p>
-      </div>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Presentation length
+      </h2>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          How to run with your staff
-        </h2>
+      <p>
+        The presentation should take 1 hour. You should also allocate time for
+        the facilitator to prepare the session for use in your school.
+      </p>
 
-        <p>
-          You could complete the exercises individually or in teams, before discussing them together or communicating to the wider school.
-        </p>
-        <p>
-          Senior leadership teams are likely to want to oversee the process. They could also consider if it is more appropriate for another member of staff to facilitate the session and lead on follow-up, for example, a head of department.
-        </p>
-        <p>
-          You might also wish to consider asking somebody independent to facilitate the workshop to free up time to take part.
-        </p>
-        <p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        How to run with your staff
+      </h2>
 
-        </p>
-        <p>
-          Provide a supportive environment for open and honest professional
-          dialogue.
-        </p>
-      </div>
+      <p>
+        You could complete the exercises individually or in teams, before
+        discussing them together or communicating to the wider school.  
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          Supporting resources
-        </h2>
+      <p>
+        Senior leadership teams are likely to want to oversee the process. They
+        could also consider if it is more appropriate for another member of
+        staff to facilitate the session and lead on follow-up, for example, a
+        head of department. 
+      </p>
 
-        <ul class="resource-card-group">
-          <%= render('/partials/resource_card_with_image.*', title: "Review how data is collected" ,
-            body: "A template to help you review how data is collected." ,
-            image_url: "/assets/images/data-management--review-and-streamline-data-mangement.jpg" ,
-            tag: "Template" , download_links: [
-              {
-                href: "#{@base_url}/assets/files/Review how data is collected.docx",
-                text: "Download Microsoft Word Document",
-                details: "DOCX, 31KB, 1 page",
-              },
-              {
-                href: "#{@base_url}/assets/files/Review how data is collected.odt",
-                text: "Download OpenDocument Text",
-                details: "ODP, 6KB, 1 page",
-              },
-            ]
-          ) %>
-        </ul>
-      </div>
+      <p>
+        You might also wish to consider asking somebody independent to
+        facilitate the workshop to free up time to take part. 
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row govuk-!-margin-top-6">
+      <p>
+        Provide a supportive environment for open and honest professional
+        dialogue.
+      </p>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Supporting resources
+      </h2>
+
+      <ul class="resource-card-group">
+        <%= render('/partials/resource_card_with_image.*', title: "Review how data is collected" ,
+          body: "A template to help you review how data is collected." ,
+          image_url: "/assets/images/data-management--review-and-streamline-data-mangement.jpg" ,
+          tag: "Template" , download_links: [
+            {
+              href: "#{@base_url}/assets/files/Review how data is collected.docx",
+              text: "Download Microsoft Word Document",
+              details: "DOCX, 31KB, 1 page",
+            },
+            {
+              href: "#{@base_url}/assets/files/Review how data is collected.odt",
+              text: "Download OpenDocument Text",
+              details: "ODP, 6KB, 1 page",
+            },
+          ]
+        ) %>
+      </ul>
+
+      <div class="govuk-!-margin-top-8">
         <%= render '/partials/share_this_resource.*' %>
       </div>
     </div>
@@ -148,4 +145,3 @@ title: Review and streamline data management
     </div>
   </div>
 </div>
-

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/cut-down-your-marking-workload.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/cut-down-your-marking-workload.md
@@ -22,23 +22,24 @@ title: Cut down your marking workload
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Within a term of encouraging teachers to try alternative approaches, some teachers said their marking workload had reduced by up to 75%. Several teachers said they “couldn’t believe we used to spend four hours on a set of exercise books. Now I spend much less time marking.”  
-      </p>
-      <p>
-      To make sure marking was contributing to pupil progress, we rigorously monitored the quality of feedback by asking pupils “what are you doing well in this subject?” and “what do you need to do to improve in this subject?”
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Within a term of encouraging teachers to try alternative approaches, some
+    teachers said their marking workload had reduced by up to 75%. Several
+    teachers said they “couldn’t believe we used to spend four hours on a set of
+    exercise books. Now I spend much less time marking.”
+  </p>
+  <p>
+    To make sure marking was contributing to pupil progress, we rigorously
+    monitored the quality of feedback by asking pupils “what are you doing well
+    in this subject?” and “what do you need to do to improve in this subject?”
+  </p>
 </div>
 
 ## Background from David Lowbridge-Ellis, Deputy Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-and-avoid-marking-in-primary-schools.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-and-avoid-marking-in-primary-schools.md
@@ -22,20 +22,16 @@ title: Give feedback and avoid marking in primary schools
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Different types of feedback help motivate pupils to progress and avoid burdensome marking practices.        
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Different types of feedback help motivate pupils to progress and avoid burdensome marking practices.        
+  </p>
 </div>
 
 ## Background from Tess Fielden, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-effectively-without-creating-an-unmanageable-workload.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/give-feedback-effectively-without-creating-an-unmanageable-workload.md
@@ -22,37 +22,33 @@ title: Give feedback effectively without creating an unmanageable workload
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Outwood Grange Academies Trust has created a culture where teachers give feedback effectively without creating an unmanageable workload. 
-      </p>
-      <p>
-        Thanks to their approach, teachers are innovative in how they provide feedback. They’re empowered to:
-        <ul>
-          <li>give feedback and mark in a way that best suits their subject and pupils</li>
-          <li>use a wide variety of feedback strategies such as verbal feedback and live marking</li>
-        </ul>
-      </p>
-      <p>
-        Teachers are also more selective in what, why and how they mark. They:
-        <ul>
-          <li>focus on what makes a difference in written marking</li>
-          <li>mark for pupils - not leaders</li>
-        </ul>
-      </p>
-      <p>
-      Workload has also reduced and there is a better balance between time spent on planning and marking. Pupils are more actively engaged in checking their own work and responding to feedback.
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Outwood Grange Academies Trust has created a culture where teachers give feedback effectively without creating an unmanageable workload. 
+  </p>
+  <p>
+    Thanks to their approach, teachers are innovative in how they provide feedback. They’re empowered to:
+    <ul>
+      <li>give feedback and mark in a way that best suits their subject and pupils</li>
+      <li>use a wide variety of feedback strategies such as verbal feedback and live marking</li>
+    </ul>
+  </p>
+  <p>
+    Teachers are also more selective in what, why and how they mark. They:
+    <ul>
+      <li>focus on what makes a difference in written marking</li>
+      <li>mark for pupils - not leaders</li>
+    </ul>
+  </p>
+  <p>
+  Workload has also reduced and there is a better balance between time spent on planning and marking. Pupils are more actively engaged in checking their own work and responding to feedback.
+  </p>
 </div>
 
 ## Background from Lynn James, Executive Principal

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/improve-how-you-give-feedback-to-primary-pupils.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/improve-how-you-give-feedback-to-primary-pupils.md
@@ -22,20 +22,16 @@ title: Improve how you give feedback to primary pupils
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        Our approach has helped to reduce workload by empowering teachers to make professional judgements about when and how to give feedback to students. This means that all the time and effort of marking and feedback is focused on having an impact on the students rather than ticking a box. 
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Our approach has helped to reduce workload by empowering teachers to make professional judgements about when and how to give feedback to students. This means that all the time and effort of marking and feedback is focused on having an impact on the students rather than ticking a box. 
+  </p>
 </div>
 
 ## Background from Ben Levinson, Headteacher

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
@@ -5,144 +5,132 @@ title: Review and streamline feedback and marking
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container govuk-grid-row two-column-page content-section--purple">
     <div class="govuk-grid-column-two-thirds">
-      <div class="dfe-width-container govuk-grid-row">
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline feedback and marking</h1>
-        <div class="dfe-width-container govuk-grid-row govuk-!-margin-bottom-7">
-          <strong class="govuk-tag">Presentation</strong>
-        </div>
-        <div class="dfe-width-container govuk-grid-row">
-          <p>
-            Use this presentation in a staff meeting or INSET day to review and
-            streamline your feedback and marking processes.
-          </p>
-          <p>
-            The presentation includes:
-          <ul>
-            <li>background and contextual information</li>
-            <li>the purposes of feedback and marking</li>
-            <li>reviewing current practice</li>
-            <li>next steps</li>
-          </ul>
-          </p>
-        </div>
-      </div>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline feedback and marking</h1>
 
-      <div class="govuk-grid-row dfe-width-container">
-        <div class="govuk-grid-column-full">
-          <div class="info-box">
-            <div class="info-box__corner">
-              <img src="/assets/images/download-icon.svg" alt="Download icon">
-            </div>
-            <h2 class="govuk-heading-m">
-              Download the presentation
-            </h2>
-            <div class="govuk-grid-row info-box__download-content">
-              <div class="govuk-grid-column-one-half">
-                <img src="/assets/images/feedback-and-marking--review-and-streamline-feedback-and-marking.jpg" alt="Review and streamline feedback and marking" class="dfe-file-preview-image">
-              </div>
-              <div class="govuk-grid-column-one-half">
-                <div class="info-box__content">
-                  <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.pptx">
-                    Download Microsoft PowerPoint
-                  </a>
-                  <p>
-                    PPTX, 92KB, 7 slides
-                  </p>
-                  <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
-                    Download OpenDocument Presentation
-                  </a>
-                  <p>
-                    ODP, 177KB, 7 slides
-                  </p>
-                </div>
-              </div>
+      <p class="govuk-!-margin-bottom-7">
+        <strong class="govuk-tag">Presentation</strong>
+      </p>
+
+      <p>
+        Use this presentation in a staff meeting or INSET day to review and
+        streamline your feedback and marking processes.
+      </p>
+
+      <p>
+        The presentation includes:
+      </p>
+
+      <ul>
+        <li>background and contextual information</li>
+        <li>the purposes of feedback and marking</li>
+        <li>reviewing current practice</li>
+        <li>next steps</li>
+      </ul>
+
+      <div class="info-box">
+        <div class="info-box__corner">
+          <img src="/assets/images/download-icon.svg" alt="Download icon">
+        </div>
+        <h2 class="govuk-heading-m">
+          Download the presentation
+        </h2>
+        <div class="govuk-grid-row info-box__download-content">
+          <div class="govuk-grid-column-one-half">
+            <img src="/assets/images/feedback-and-marking--review-and-streamline-feedback-and-marking.jpg" alt="Review and streamline feedback and marking" class="dfe-file-preview-image">
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <div class="info-box__content">
+              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.pptx">
+                Download Microsoft PowerPoint
+              </a>
+              <p>
+                PPTX, 92KB, 7 slides
+              </p>
+              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
+                Download OpenDocument Presentation
+              </a>
+              <p>
+                ODP, 177KB, 7 slides
+              </p>
             </div>
           </div>
         </div>
       </div>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
-          Audience
-        </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+        Audience
+      </h2>
 
-        <p>
-          This resource has been provided to support senior leadership teams to
-          run a session with the whole school, teams or departments.
-        </p>
-      </div>
+      <p>
+        This resource has been provided to support senior leadership teams to
+        run a session with the whole school, teams or departments.
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          Presentation length
-        </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Presentation length
+      </h2>
 
-        <p>
-          The presentation should take 1 hour and 15 minutes. You should also
-          allocate time for the facilitator to prepare the session for use in
-          your school.
-        </p>
-      </div>
+      <p>
+        The presentation should take 1 hour and 15 minutes. You should also
+        allocate time for the facilitator to prepare the session for use in
+        your school.
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          How to run with your staff
-        </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        How to run with your staff
+      </h2>
 
-        <p>
-          Depending on the situation in your school, you might wish to use this
-          workshop as a starting point to initiate further exploration. You can
-          also use it to prepare for the workshop with activities beforehand.
-        </p>
-        <p>
-          This could include your senior leadership team discussing:
-          <ul>
-            <li>to what extent teachers follow your existing policy – and how you know?</li>
-            <li>can you clearly articulate what you expect from teachers – and is it reasonable?</li>
-            <li>do you have evidence to support the practices in your current policy?</li>
-            <li>how does your policy compare with examples from other schools?</li>
-          </ul>
-        </p>
-        <p>
-          Senior leadership teams are likely to want to oversee the process.
-          However they may want to consider if another staff member could
-          facilitate the session and lead on follow-up, for example, a head of
-          department. Alternatively, you might want to consider asking an
-          independent person to facilitate the workshop, to free up time to take
-          part.
-        </p>
-        <p>
-          Provide a supportive environment for open and honest professional
-          dialogue.
-        </p>
-      </div>
-
-      <div class="dfe-width-container govuk-grid-row">
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-          Supporting resources
-        </h2>
-
-        <ul class="resource-card-group">
-          <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
-            body: "A template to help you prioritise what to address first." ,
-            image_url: "/assets/images/communications--impact-graph.jpg" ,
-            tag: "Template" , download_links: [
-              {
-                href: "#{@base_url}/assets/files/Impact graph.docx",
-                text: "Download Microsoft Word Document",
-                details: "DOCX, 31KB, 1 page",
-              },
-              {
-                href: "#{@base_url}/assets/files/Impact graph.odt",
-                text: "Download OpenDocument Text",
-                details: "ODP, 6KB, 1 page",
-              },
-            ]
-          ) %>
+      <p>
+        Depending on the situation in your school, you might wish to use this
+        workshop as a starting point to initiate further exploration. You can
+        also use it to prepare for the workshop with activities beforehand.
+      </p>
+      <p>
+        This could include your senior leadership team discussing: 
+        <ul>
+          <li>to what extent teachers follow your existing policy – and how you know?</li>
+          <li>can you clearly articulate what you expect from teachers – and is it reasonable?</li>
+          <li>do you have evidence to support the practices in your current policy?</li>
+          <li>how does your policy compare with examples from other schools?</li>
         </ul>
-      </div>
+      </p>
+      <p>
+        Senior leadership teams are likely to want to oversee the process.
+        However they may want to consider if another staff member could
+        facilitate the session and lead on follow-up, for example, a head of
+        department. Alternatively, you might want to consider asking an
+        independent person to facilitate the workshop, to free up time to take
+        part.
+      </p>
+      <p>
+        Provide a supportive environment for open and honest professional
+        dialogue.
+      </p>
 
-      <div class="dfe-width-container govuk-grid-row govuk-!-margin-top-6">
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Supporting resources
+      </h2>
+
+      <ul class="resource-card-group">
+        <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
+          body: "A template to help you prioritise what to address first." ,
+          image_url: "/assets/images/communications--impact-graph.jpg" ,
+          tag: "Template" , download_links: [
+            {
+              href: "#{@base_url}/assets/files/Impact graph.docx",
+              text: "Download Microsoft Word Document",
+              details: "DOCX, 31KB, 1 page",
+            },
+            {
+              href: "#{@base_url}/assets/files/Impact graph.odt",
+              text: "Download OpenDocument Text",
+              details: "ODP, 6KB, 1 page",
+            },
+          ]
+        ) %>
+      </ul>
+
+      <div class="govuk-!-margin-top-8">
         <%= render '/partials/share_this_resource.*' %>
       </div>
     </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
@@ -20,26 +20,22 @@ title: Review marking practice with an impact matrix
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-         Using the impact matrix to review marking practices at the City of
-         Norwich School has meant that:
-        <ul>
-          <li>homework activities have been simplified and marking criteria removed</li>
-          <li>mid-unit tests became shorter and more positively structured</li>
-          <li>tasks became much easier to mark and celebrate</li>
-       </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    Using the impact matrix to review marking practices at the City of
+    Norwich School has meant that:
+  </p>
+  <ul>
+    <li>homework activities have been simplified and marking criteria removed</li>
+    <li>mid-unit tests became shorter and more positively structured</li>
+    <li>tasks became much easier to mark and celebrate</li>
+  </ul>
 </div>
 
 ## Background from Joanne Philpott, Headteacher
@@ -55,35 +51,31 @@ create and complete the impact matrix.
 
 {/inset-text}
 
-<div class="dfe-width-container govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the impact matrix template
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/feedback-and-marking--impact-matrix-template.jpg" alt="Impact matrix template" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <div class="info-box__content">
-             <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.docx">
-              Download Microsoft Word Document
-            </a>
-            <p>
-              DOCX, 25KB, 1 page
-            </p>
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.odt">
-              Download OpenDocument Text
-            </a>
-            <p>
-              ODT, 7KB, 1 page
-            </p>
-          </div>
-        </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the impact matrix template
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/feedback-and-marking--impact-matrix-template.jpg" alt="Impact matrix template" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <div class="info-box__content">
+        <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.docx">
+          Download Microsoft Word Document
+        </a>
+        <p>
+          DOCX, 25KB, 1 page
+        </p>
+        <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.odt">
+          Download OpenDocument Text
+        </a>
+        <p>
+          ODT, 7KB, 1 page
+        </p>
       </div>
     </div>
   </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/secondary-school-feedback-policy.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/secondary-school-feedback-policy.md
@@ -22,26 +22,25 @@ title: Secondary school feedback policy
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        This policy reduced the time teachers spent marking where it was not having an impact on pupil progress. 
-      </p>
-      <p>
-        Marking for progress has encouraged some departments to amend their assessment schemes at key stage 3.
-      </p>
-      <p>
-        For pupils, it allowed misconceptions to be highlighted and gave them time to understand what they need to do to progress. 
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    This policy reduced the time teachers spent marking where it was not having
+    an impact on pupil progress.
+  </p>
+  <p>
+    Marking for progress has encouraged some departments to amend their
+    assessment schemes at key stage 3.
+  </p>
+  <p>
+    For pupils, it allowed misconceptions to be highlighted and gave them time
+    to understand what they need to do to progress.
+  </p>
 </div>
 
 ## Background from Tony McCabe, Headteacher
@@ -58,7 +57,6 @@ All feedback:
 
 - informs pupil progress
 - has a positive impact on pupil outcomes
-
 - is a good use of teachers’ time
 
 The more immediate the feedback the greater the impact. All subject areas have identified a minimum standard in terms of regularity of feedback, taking into consideration lesson frequency and the nature of the subject.

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/try-ideas-to-manage-feedback-and-marking.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/try-ideas-to-manage-feedback-and-marking.md
@@ -22,32 +22,30 @@ title: Try ideas to manage feedback and marking workload
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We made these changes to enable every teacher to become highly effective by:
-      </p>
-      <ul>
-        <li>
-          ensuring every teacher has time to focus on what is important - planning, teaching and feedback
-        </li>
-        <li>
-          believing in simplicity, always taking the shortest route and aiming for maximum impact on student learning with minimal workload for staff 
-        </li>
-        <li>
-          continuously reviewing and evaluating our systems in order to support all staff to achieve a healthy work life balance
-        </li>
-     </ul> 
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We made these changes to enable every teacher to become highly effective by:
+  </p>
+  <ul>
+    <li>
+      ensuring every teacher has time to focus on what is important - planning,
+      teaching and feedback
+    </li>
+    <li>
+      believing in simplicity, always taking the shortest route and aiming for
+      maximum impact on student learning with minimal workload for staff
+    </li>
+    <li>
+      continuously reviewing and evaluating our systems in order to support all
+      staff to achieve a healthy work life balance
+    </li>
+  </ul>
 </div>
 
 ## Background from Ruth Allen, Deputy Headteacher

--- a/content/workload-reduction-toolkit/evaluate-workload-measures.html.erb
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures.html.erb
@@ -3,9 +3,9 @@ title: Evaluate workload measures
 colour: green
 ---
 
-<div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row two-column-page content-section--green">
-    <div class="dfe-width-container govuk-grid-row">
+<div class="govuk-main-wrapper two-column-page content-section--green">
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Evaluate workload measures</h1>
         <p>
@@ -19,70 +19,71 @@ colour: green
       </div>
     </div>
 
-
-    <div class="dfe-width-container govuk-grid-row">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-grid-row dfe-width-container">
-          <div class="info-box">
-            <div class="info-box__corner">
-              <img src="/assets/images/i-icon.svg" alt="info icon">
-            </div>
-            <h2 class="govuk-heading-m">
-              How to use this section
-            </h2>
-            <p>
-              You can use and adapt these resources to help monitor the impact
-              of your workload reduction measures. Evaluation methods can
-              include:
-            </p>
-            <p>
-              <ul>
-                <li>conducting surveys with school staff, pupils, parents and carers</li>
-                <li>reviewing the results of pupils</li>
-                <li>trialling different teaching approaches with parallel classes</li>
-              </ul>
-            </p>
-            <p>
-              As a senior leadership team, you could use these resources to
-              provide regular feedback to school staff and governors.
-            </p>
+        <div class="info-box govuk-!-margin-top-8">
+          <div class="info-box__corner">
+            <img src="/assets/images/i-icon.svg" alt="info icon">
           </div>
-        </div>
-
-        <div class="dfe-width-container govuk-grid-row">
           <h2 class="govuk-heading-m">
-            Resources to help evaluate workload reduction measures
+            How to use this section
           </h2>
-
-          <ul class="resource-card-group">
-            <%= render('/partials/resource_card.*',
-              title: "Evaluate impact using a staff workload survey",
-              href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/staff-workload-survey",
-              body: "Gather feedback from staff and teachers about your workload reduction measures.",
-              tag: "Template",
-              details: { reading_time: "1 minute" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Evaluate progress with staff",
-              href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/evaluate-progress-with-staff",
-              body: "Show staff the actions you took to address workload issues and gather feedback.",
-              tag: "Template",
-              details: { reading_time: "1 minute" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Have structured conversations to evaluate outcomes",
-              href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/structured-conversations-with-staff",
-              body: "Talk to staff and teachers about their biggest workload issues.",
-              tag: "Template", details: { reading_time: "1 minute" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Update your workload action plan",
-              href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/update-your-workload-action-plan",
-              body: "Evaluate the actions you took to reduce workload in your school.",
-              tag: "Example",
-              details: { reading_time: "1 minute", created_by: "Notre Dame High School (Secondary)"}) %>
-          </ul>
+          <p>
+            You can use and adapt these resources to help monitor the impact
+            of your workload reduction measures. Evaluation methods can
+            include:
+          </p>
+          <p>
+            <ul>
+              <li>
+                conducting surveys with school staff, pupils, parents and carers
+              </li>
+              <li>
+                reviewing the results of pupils
+              </li>
+              <li>
+                trialling different teaching approaches with parallel classes
+              </li>
+            </ul>
+          </p>
+          <p>
+            As a senior leadership team, you could use these resources to
+            provide regular feedback to school staff and governors.
+          </p>
         </div>
+
+        <h2 class="govuk-heading-m">
+          Resources to help evaluate workload reduction measures
+        </h2>
+
+        <ul class="resource-card-group">
+          <%= render('/partials/resource_card.*',
+            title: "Evaluate impact using a staff workload survey",
+            href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/staff-workload-survey",
+            body: "Gather feedback from staff and teachers about your workload reduction measures.",
+            tag: "Template",
+            details: { reading_time: "1 minute" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Evaluate progress with staff",
+            href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/evaluate-progress-with-staff",
+            body: "Show staff the actions you took to address workload issues and gather feedback.",
+            tag: "Template",
+            details: { reading_time: "1 minute" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Have structured conversations to evaluate outcomes",
+            href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/structured-conversations-with-staff",
+            body: "Talk to staff and teachers about their biggest workload issues.",
+            tag: "Template", details: { reading_time: "1 minute" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Update your workload action plan",
+            href: "#{@base_url}/workload-reduction-toolkit/evaluate-workload-measures/update-your-workload-action-plan",
+            body: "Evaluate the actions you took to reduce workload in your school.",
+            tag: "Example",
+            details: { reading_time: "1 minute", created_by: "Notre Dame High School (Secondary)"}) %>
+        </ul>
       </div>
 
       <div class="govuk-grid-column-one-third">

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/evaluate-progress-with-staff.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/evaluate-progress-with-staff.md
@@ -10,34 +10,34 @@ colour: green
 Use this template to show your staff the actions you have taken, or will take, to address workload issues identified in
 your school. Gather feedback and evaluate if any actions taken have had an impact on their workload.
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the template
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify--share-progress-with-staff.jpg" alt="Share progress with staff" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 27KB, 1 page
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 8KB, 1 page
-          </p>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the template
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify--share-progress-with-staff.jpg" alt="Share progress with staff" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <p class="govuk-body-m govuk-!-margin-top-3 govuk-!-margin-bottom-0">
+        <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
+          Download Microsoft Word Document
+        </a>
+      </p>
+      <p class="govuk-body-m">
+        DOCX, 27KB, 1 page
+      </p>
+      <p class="govuk-body-m govuk-!-margin-top-3 govuk-!-margin-bottom-0">
+        <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
+          Download Open Source Document
+        </a>
+      </p>
+      <p class="govuk-body-m">
+        ODT, 8KB, 1 page
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/staff-workload-survey.md
@@ -13,57 +13,53 @@ Identify section of the toolkit regularly to gather feedback from school staff o
 effectiveness of your workload reduction measures. You can use this feedback to evaluate and
 refine any actions you’ve taken to reduce workload.
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Edit the survey
-      </h2>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Edit the survey
+  </h2>
+  <p>
+    The survey can be edited to meet the needs of your setting and
+    you can add, change or remove questions if required. For
+    example, some parts of the survey may be more appropriate for
+    primary or secondary settings.
+  </p>
+  <h2 class="govuk-heading-m">
+    Use the online versions of the survey
+  </h2>
+  <p>
+    You can duplicate and adapt
+    <a href="https://forms.office.com/Pages/ShareFormPage.aspx?id=yXfS-grGoU2187O4s0qC-cn26r-uTMpNqURSfi9lRcVUNEg1UTdMMllFRTM1SEVRRDJWQjE3RUU5VS4u&sharetoken=MJnNysyL44umvL8f97JA" class="govuk-link">
+      this online version
+    </a>
+    of the staff workload survey.
+  </p>
+  <p>
+    Some schools find online surveys easier to share with staff than a paper
+    form because they collate the results automatically for you.
+  </p>
+  <h2 class="govuk-heading-m">
+    Download the staff workload survey
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify-and-evaluate-survey.jpeg" alt="Staff workload survey" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
+        Download Microsoft Word Document
+      </a>
       <p>
-        The survey can be edited to meet the needs of your setting and
-        you can add, change or remove questions if required. For
-        example, some parts of the survey may be more appropriate for
-        primary or secondary settings.
+        DOCX, 31KB, 4 pages
       </p>
-      <h2 class="govuk-heading-m">
-        Use the online versions of the survey
-      </h2>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
+        Download OpenDocument Text
+      </a>
       <p>
-        You can duplicate and adapt
-        <a href="https://forms.office.com/Pages/ShareFormPage.aspx?id=yXfS-grGoU2187O4s0qC-cn26r-uTMpNqURSfi9lRcVUNEg1UTdMMllFRTM1SEVRRDJWQjE3RUU5VS4u&sharetoken=MJnNysyL44umvL8f97JA" class="govuk-link">
-          this online version
-        </a>
-        of the staff workload survey.
+        ODT, 16KB, 4 pages
       </p>
-      <p>
-        Some schools find online surveys easier to share with staff than a paper
-        form because they collate the results automatically for you.
-      </p>
-      <h2 class="govuk-heading-m">
-        Download the staff workload survey
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify-and-evaluate-survey.jpeg" alt="Staff workload survey" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 31KB, 4 pages
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 16KB, 4 pages
-          </p>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/structured-conversations-with-staff.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/structured-conversations-with-staff.md
@@ -9,34 +9,30 @@ colour: green
 
 A structured conversation template to help gather feedback from staff and teachers about your workload reduction measures.
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the template
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/evaluate--structured-conversation-template.jpg" alt="Structured conversation template" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 28KB, 1 page
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.odt">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 8KB, 1 page
-          </p>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the template
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/evaluate--structured-conversation-template.jpg" alt="Structured conversation template" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.docx">
+        Download Microsoft Word Document
+      </a>
+      <p>
+        DOCX, 28KB, 1 page
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.odt">
+        Download Open Source Document
+      </a>
+      <p>
+        ODT, 8KB, 1 page
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/update-your-workload-action-plan.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/update-your-workload-action-plan.md
@@ -23,34 +23,30 @@ colour: green
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the example
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify-and-evaluate--action-plan.jpg" alt="Workload action plan" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 29KB, 2 pages
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 11KB, 2 pages
-          </p>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the template
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify-and-evaluate--action-plan.jpg" alt="Workload action plan" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
+        Download Microsoft Word Document
+      </a>
+      <p>
+        DOCX, 29KB, 2 pages
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
+        Download OpenDocument Text
+      </a>
+      <p>
+        ODT, 11KB, 2 pages
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues.html.erb
+++ b/content/workload-reduction-toolkit/identify-workload-issues.html.erb
@@ -3,9 +3,9 @@ title: Identify workload issues
 colour: pink
 ---
 
-<div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row two-column-page content-section--pink">
-    <div class="dfe-width-container govuk-grid-row">
+<div class="govuk-main-wrapper two-column-page content-section--pink">
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h1 class="govuk-heading-l">Identify workload issues</h1>
         <p>
@@ -15,110 +15,104 @@ colour: pink
       </div>
     </div>
 
-    <div class="dfe-width-container govuk-grid-row">
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-grid-row dfe-width-container">
-          <div class="info-box">
-            <div class="info-box__corner">
-              <img src="/assets/images/i-icon.svg" alt="info icon">
-            </div>
-            <h2 class="govuk-heading-m">
-              How to use this section
-            </h2>
-            <p>
-              You can choose the resources you want to use and adapt them for your
-              school context. They will help you:
-            </p>
-            <p>
-              <ul>
-                <li>identify the causes of the biggest workload issues</li>
-                <li>understand how your staff feel about workload</li>
-                <li>
-                  prioritise
-                  <a href="<%= @base_url %>/workload-reduction-toolkit/address-workload-issues" class="govuk-link">specific workload areas</a>
-                </li>
-              </ul>
-            </p>
-            <p>
-              As a senior leadership team, decide whether you will address
-              workload across the whole school, by department or in individual
-              teams.
-            </p>
-            <p>
-              Regularly reviewing workload with all your staff will help you to
-              understand workload issues and evaluate the impact you are having.
-            </p>
+        <div class="info-box govuk-!-margin-top-8">
+          <div class="info-box__corner">
+            <img src="/assets/images/i-icon.svg" alt="info icon">
           </div>
-        </div>
-
-        <div class="dfe-width-container govuk-grid-row">
           <h2 class="govuk-heading-m">
-            Resources to help identify workload issues
+            How to use this section
           </h2>
-
-          <ul class="resource-card-group">
-            <%= render('/partials/resource_card.*',
-              title: "Identify issues using a staff workload survey",
-              href: "#{base_url}/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey",
-              body: "Gather information from staff and teachers about their biggest workload issues.",
-              tag: "Template",
-              details: { reading_time: "3 minutes" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Act on your staff workload survey",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey",
-              body: "Share the results of your workload survey with staff and decide how to act.",
-              tag: "Presentation") %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Plan your yearly calendar",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar",
-              body: "Review your calendar with staff to identify workload issues and resolve them.",
-              tag: "Presentation") %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Have structured conversations to identify issues",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues",
-              body: "Talk to staff and teachers about their biggest workload issues.",
-              tag: "Template",
-              details: { reading_time: "1 minute" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Use an INSET day to focus on reducing workload",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload",
-              body: "Read how a school used an INSET day to focus on what gets in the way of teaching.",
-              tag: "Case study",
-              details: { reading_time: "2 minutes", created_by: "Kensington Primary School" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Prioritise change using impact graphs",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs",
-              body: "Use an impact graph to measure the impact of different tasks and prioritise change.",
-              tag: "Template",
-              details: { reading_time: "2 minutes" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Create an action plan to reduce workload",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload",
-              body: "Create an action plan to focus on reducing workload.",
-              tag: "Example",
-              details: { reading_time: "2 minutes", created_by: "Notre Dame High School (Secondary)" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "How we addressed workload issues",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues",
-              body: "Read tips on how to address workload issues.",
-              tag: "Case study",
-              details: { reading_time: "2 minutes", created_by: "Hilltop Infant School" }) %>
-
-            <%= render('/partials/resource_card.*',
-              title: "Share progress with staff",
-              href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff",
-              body: "Show staff the actions you’ll take to address workload issues and gather feedback.",
-              tag: "Template",
-              details: { reading_time: "1 minute" }) %>
+          <p>
+            You can choose the resources you want to use and adapt them for your
+            school context. They will help you:
+          </p>
+          <ul>
+            <li>identify the causes of the biggest workload issues</li>
+            <li>understand how your staff feel about workload</li>
+            <li>
+              prioritise
+              <a href="<%= @base_url %>/workload-reduction-toolkit/address-workload-issues" class="govuk-link">specific workload areas</a>
+            </li>
           </ul>
+          <p>
+            As a senior leadership team, decide whether you will address
+            workload across the whole school, by department or in individual
+            teams.
+          </p>
+          <p>
+            Regularly reviewing workload with all your staff will help you to
+            understand workload issues and evaluate the impact you are having.
+          </p>
         </div>
+
+        <h2 class="govuk-heading-m">
+          Resources to help identify workload issues
+        </h2>
+
+        <ul class="resource-card-group">
+          <%= render('/partials/resource_card.*',
+            title: "Identify issues using a staff workload survey",
+            href: "#{base_url}/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey",
+            body: "Gather information from staff and teachers about their biggest workload issues.",
+            tag: "Template",
+            details: { reading_time: "3 minutes" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Act on your staff workload survey",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey",
+            body: "Share the results of your workload survey with staff and decide how to act.",
+            tag: "Presentation") %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Plan your yearly calendar",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar",
+            body: "Review your calendar with staff to identify workload issues and resolve them.",
+            tag: "Presentation") %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Have structured conversations to identify issues",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues",
+            body: "Talk to staff and teachers about their biggest workload issues.",
+            tag: "Template",
+            details: { reading_time: "1 minute" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Use an INSET day to focus on reducing workload",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload",
+            body: "Read how a school used an INSET day to focus on what gets in the way of teaching.",
+            tag: "Case study",
+            details: { reading_time: "2 minutes", created_by: "Kensington Primary School" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Prioritise change using impact graphs",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs",
+            body: "Use an impact graph to measure the impact of different tasks and prioritise change.",
+            tag: "Template",
+            details: { reading_time: "2 minutes" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Create an action plan to reduce workload",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload",
+            body: "Create an action plan to focus on reducing workload.",
+            tag: "Example",
+            details: { reading_time: "2 minutes", created_by: "Notre Dame High School (Secondary)" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "How we addressed workload issues",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues",
+            body: "Read tips on how to address workload issues.",
+            tag: "Case study",
+            details: { reading_time: "2 minutes", created_by: "Hilltop Infant School" }) %>
+
+          <%= render('/partials/resource_card.*',
+            title: "Share progress with staff",
+            href: "#{@base_url}/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff",
+            body: "Show staff the actions you’ll take to address workload issues and gather feedback.",
+            tag: "Template",
+            details: { reading_time: "1 minute" }) %>
+        </ul>
       </div>
 
       <div class="govuk-grid-column-one-third">

--- a/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
@@ -14,34 +14,30 @@ staff workload survey, prioritise next steps and identify:
 - what you can streamline whilst maintaining standards
 - any areas that are not covered in the survey results
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the presentation
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify--act-on-your-staff-survey.jpg" alt="Act on your staff workload survey" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.pptx">
-            Download Microsoft PowerPoint
-          </a>
-          <p>
-            PPTX, 90KB, 4 slides
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.odp">
-            Download OpenDocument Presentation
-          </a>
-          <p>
-            ODP, 204KB, 4 slides
-          </p>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the presentation
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify--act-on-your-staff-survey.jpg" alt="Act on your staff workload survey" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.pptx">
+        Download Microsoft PowerPoint
+      </a>
+      <p>
+        PPTX, 90KB, 4 slides
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.odp">
+        Download OpenDocument Presentation
+      </a>
+      <p>
+        ODP, 204KB, 4 slides
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
@@ -23,6 +23,36 @@ colour: pink
 
 {/inset-text}
 
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the example
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify-and-evaluate--action-plan.jpg" alt="Workload action plan" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <div class="info-box__content">
+        <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
+          Download Microsoft Word Document
+        </a>
+        <p>
+          DOCX, 29KB, 2 pages
+        </p>
+        <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.odt">
+          Download OpenDocument Text
+        </a>
+        <p>
+          ODT, 11KB, 2 pages
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
 ## Background from Neil Cully, Headteacher
 
 {inset-text}
@@ -35,40 +65,6 @@ The action plan outlines the key areas of focus, the actions that need to be
 taken, what success looks like and the timescale for actions to be taken.
 
 {/inset-text}
-
-<div class="dfe-width-container govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the example
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify-and-evaluate--action-plan.jpg" alt="Workload action plan" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <div class="info-box__content">
-             <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
-              Download Microsoft Word Document
-            </a>
-            <p>
-              DOCX, 29KB, 2 pages
-            </p>
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
-              Download OpenDocument Text
-            </a>
-            <p>
-              ODT, 11KB, 2 pages
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
 
 ## Creating an action plan
 

--- a/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
@@ -10,34 +10,30 @@ colour: pink
 A structured conversation template to help gather information from staff and
 teachers about their workload issues.
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the template
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify--have-structured-conversations-with-staff.jpg" alt="Have structured conversations to identify issues" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 26KB, 1 page
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.odt">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 8KB, 1 page
-          </p>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the template
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify--have-structured-conversations-with-staff.jpg" alt="Have structured conversations to identify issues" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.docx">
+        Download Microsoft Word Document
+      </a>
+      <p>
+        DOCX, 26KB, 1 page
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.odt">
+        Download OpenDocument Text
+      </a>
+      <p>
+        ODT, 8KB, 1 page
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/how-we-addressed-workload-issues.md
@@ -23,27 +23,23 @@ colour: pink
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We formed our
-        <%= link_to("Trust Workload and Wellbeing group", "https://www.heartsacademytrust.co.uk/workload-and-wellbeing") %>.
-      </p>
-      <p>
-        As a Trust we also developed a Workload and Wellbeing Charter which is
-        updated each September and mid-year if needed to ensure that messages
-        are reinforced. An annual well-being survey also supports schools to
-        understand if the charter is effective and being implemented.
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We formed our
+    <%= link_to("Trust Workload and Wellbeing group", "https://www.heartsacademytrust.co.uk/workload-and-wellbeing") %>.
+  </p>
+  <p>
+    As a Trust we also developed a Workload and Wellbeing Charter which is
+    updated each September and mid-year if needed to ensure that messages
+    are reinforced. An annual well-being survey also supports schools to
+    understand if the charter is effective and being implemented.
+  </p>
 </div>
 
 ## Background from Jane Robinson, Head of School

--- a/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
@@ -16,34 +16,30 @@ The presentation includes:
 - discussions about what aspects could be changed, streamlined or stopped
 - review of the yearly plan and pinch points
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the presentation
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify--plan-your-yearly-calendar.jpg" alt="Plan your yearly calendar" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.pptx">
-            Download Microsoft PowerPoint
-          </a>
-          <p>
-            PPTX, 115KB, 9 slides
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.odp">
-            Download OpenDocument Presentation
-          </a>
-          <p>
-            ODP, 209KB, 9 slides
-          </p>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the presentation
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify--plan-your-yearly-calendar.jpg" alt="Plan your yearly calendar" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.pptx">
+        Download Microsoft PowerPoint
+      </a>
+      <p>
+        PPTX, 115KB, 9 slides
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.odp">
+        Download OpenDocument Presentation
+      </a>
+      <p>
+        ODP, 209KB, 9 slides
+      </p>
     </div>
   </div>
 </div>
@@ -58,7 +54,7 @@ the whole school, teams or departments.
 The presentation should take 1 hour and 15 minutes. You should also allocate
 time for the facilitator to prepare the session for use in your school.
 
-## How to run with your staff 
+## How to run with your staff
 
 Use this presentation to map out your school year, considering how it impacts on
 workload. Decide if elements can be streamlined, removed, or can take place at a

--- a/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
@@ -11,37 +11,31 @@ Impact graphs are used to measure the impact of different tasks and prioritise
 change. This template is designed for use by senior leadership teams in staff
 one-to-ones, or in team or whole staff meetings.
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the impact graph template
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify--prioritise-change-using-impact-graphs.jpg" alt="Prioritise change using impact graphs" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-           <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact graph.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 31KB, 1 page
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact graph.odt">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 6KB, 1 page
-          </p>
-
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the impact graph template
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify--prioritise-change-using-impact-graphs.jpg" alt="Prioritise change using impact graphs" class="dfe-file-preview-image">
     </div>
-
+    <div class="govuk-grid-column-one-half">
+        <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact graph.docx">
+        Download Microsoft Word Document
+      </a>
+      <p>
+        DOCX, 31KB, 1 page
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact graph.odt">
+        Download OpenDocument Text
+      </a>
+      <p>
+        ODT, 6KB, 1 page
+      </p>
+    </div>
   </div>
 </div>
 

--- a/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
@@ -10,34 +10,30 @@ colour: pink
 Use this template to show your staff the actions you will take to address
 workload issues identified in your school.
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/download-icon.svg" alt="Download icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Download the template
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify--share-progress-with-staff.jpg" alt="Share progress with staff" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-           <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 27KB, 1 page
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 8KB, 1 page
-          </p>
-        </div>
-      </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/download-icon.svg" alt="Download icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Download the template
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify--share-progress-with-staff.jpg" alt="Share progress with staff" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
+        Download Microsoft Word Document
+      </a>
+      <p>
+        DOCX, 27KB, 1 page
+      </p>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
+        Download OpenDocument Text
+      </a>
+      <p>
+        ODT, 8KB, 1 page
+      </p>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
@@ -11,58 +11,54 @@ Use this survey template to gather information from school staff about their
 workload. You can address issues you identify with resources from the workload
 reduction toolkit.
 
-<div class="govuk-grid-row dfe-width-container govuk-!-padding-bottom-6">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Edit the survey
-      </h2>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/clipboard-icon.svg" alt="Clipboard icon">
+  </div>
+  <h2 class="govuk-heading-m">
+    Edit the survey
+  </h2>
+  <p>
+    The survey can be edited to meet the needs of your setting and
+    you can add, change or remove questions if required. For
+    example, some parts of the survey may be more appropriate for
+    primary or secondary settings.
+  </p>
+  <h2 class="govuk-heading-m">
+    Use the online version of the survey
+  </h2>
+  <p>
+    You can duplicate and adapt
+    <a href="https://forms.office.com/Pages/ShareFormPage.aspx?id=yXfS-grGoU2187O4s0qC-cn26r-uTMpNqURSfi9lRcVUNEg1UTdMMllFRTM1SEVRRDJWQjE3RUU5VS4u&sharetoken=MJnNysyL44umvL8f97JA"
+    class="govuk-link">
+      this online version
+    </a>
+    of the staff workload survey.
+  </p>
+  <p>
+    Some schools find online surveys easier to share with staff than a paper
+    form because they collate the results automatically for you.
+  </p>
+  <h2 class="govuk-heading-m">
+    Download the staff workload survey
+  </h2>
+  <div class="govuk-grid-row info-box__download-content">
+    <div class="govuk-grid-column-one-half">
+      <img src="/assets/images/identify-and-evaluate-survey.jpeg" alt="Staff workload survey" class="dfe-file-preview-image">
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
+        Download Microsoft PowerPoint
+      </a>
       <p>
-        The survey can be edited to meet the needs of your setting and
-        you can add, change or remove questions if required. For
-        example, some parts of the survey may be more appropriate for
-        primary or secondary settings.
+        DOCX, 31KB, 4 pages
       </p>
-      <h2 class="govuk-heading-m">
-        Use the online version of the survey
-      </h2>
+      <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
+        Download OpenDocument Text
+      </a>
       <p>
-        You can duplicate and adapt
-        <a href="https://forms.office.com/Pages/ShareFormPage.aspx?id=yXfS-grGoU2187O4s0qC-cn26r-uTMpNqURSfi9lRcVUNEg1UTdMMllFRTM1SEVRRDJWQjE3RUU5VS4u&sharetoken=MJnNysyL44umvL8f97JA"
-        class="govuk-link">
-          this online version
-        </a>
-        of the staff workload survey.
+        ODT, 16KB, 4 pages
       </p>
-      <p>
-        Some schools find online surveys easier to share with staff than a paper
-        form because they collate the results automatically for you.
-      </p>
-      <h2 class="govuk-heading-m">
-        Download the staff workload survey
-      </h2>
-      <div class="govuk-grid-row info-box__download-content">
-        <div class="govuk-grid-column-one-half">
-          <img src="/assets/images/identify-and-evaluate-survey.jpeg" alt="Staff workload survey" class="dfe-file-preview-image">
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
-            Download Microsoft Word Document
-          </a>
-          <p>
-            DOCX, 31KB, 4 pages
-          </p>
-          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
-            Download OpenDocument Text
-          </a>
-          <p>
-            ODT, 16KB, 4 pages
-          </p>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/use-an-inset-day-to-focus-on-reducing-workload.md
@@ -23,30 +23,26 @@ colour: pink
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        We have relentlessly removed unnecessary tasks or reduced them to their
-        essential components, especially when the justification for doing them
-        was ‘that’s what everyone else does’ or ‘that’s what OFSTED, DfE or some
-        other body want. The marking policy (now included in this service’s
-        school workload reduction toolkit) was one outcome of this wider work.
-      </p>
-      <p>
-        As a result, in our most recent wellbeing survey, 95% of our staff
-        believed they completed their work ‘on time’ and, consequently, over 70%
-        answered ‘very much so’ to the question: do you have a life outside
-        work?
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    We have relentlessly removed unnecessary tasks or reduced them to their
+    essential components, especially when the justification for doing them
+    was ‘that’s what everyone else does’ or ‘that’s what OFSTED, DfE or some
+    other body want. The marking policy (now included in this service’s
+    school workload reduction toolkit) was one outcome of this wider work.
+  </p>
+  <p>
+    As a result, in our most recent wellbeing survey, 95% of our staff
+    believed they completed their work ‘on time’ and, consequently, over 70%
+    answered ‘very much so’ to the question: do you have a life outside
+    work?
+  </p>
 </div>
 
 ## Background from Ben Levinson, Headteacher

--- a/docs/adding-a-resource.md
+++ b/docs/adding-a-resource.md
@@ -64,24 +64,20 @@ written in HTML. The following code snippets are used in
 ![info box](<Screenshot 2024-02-06 at 12.23.49.png>)
 
 ```html
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon" />
-      </div>
-      <h2 class="govuk-heading-m">Impact and outcomes</h2>
-      <p>
-        INSERT-IMPACT-AND-OUTCOMES
-      </p>
-      <p>
-        <ul>
-          <li>first list item</li>
-          <li>second list item</li>
-        </ul>
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon" />
   </div>
+  <h2 class="govuk-heading-m">Impact and outcomes</h2>
+  <p>
+    INSERT-IMPACT-AND-OUTCOMES
+  </p>
+  <p>
+    <ul>
+      <li>first list item</li>
+      <li>second list item</li>
+    </ul>
+  </p>
 </div>
 ```
 

--- a/docs/example-resource.md
+++ b/docs/example-resource.md
@@ -22,20 +22,16 @@ title: INSERT-TITLE
 
 {/inset-text}
 
-<div class="govuk-grid-row dfe-width-container">
-  <div class="govuk-grid-column-full">
-    <div class="info-box">
-      <div class="info-box__corner">
-        <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
-      </div>
-      <h2 class="govuk-heading-m">
-        Impact and outcomes
-      </h2>
-      <p>
-        INSERT-IMPACT-AND-OUTCOMES
-      </p>
-    </div>
+<div class="info-box">
+  <div class="info-box__corner">
+    <img src="/assets/images/bullseye.svg" alt="Bullseye icon">
   </div>
+  <h2 class="govuk-heading-m">
+    Impact and outcomes
+  </h2>
+  <p>
+    INSERT-IMPACT-AND-OUTCOMES
+  </p>
 </div>
 
 ## Background from INSERT-CONTACT-NAME

--- a/layouts/explore_resources.html.erb
+++ b/layouts/explore_resources.html.erb
@@ -26,16 +26,11 @@
         <%= yield %>
         </div>
       </div>
-    </div>
-  </div>
 
-  <div class="govuk-main-wrapper">
-    <div class="dfe-width-container govuk-grid-row">
-      <hr class="govuk-!-margin-top-0" />
+      <hr class="govuk-!-margin-top-9" />
       <%= render '/partials/feedback.*' %>
     </div>
   </div>
-
 <% end %>
 
 <%= render '/base.html.erb' %>

--- a/layouts/markdown_layout.html.erb
+++ b/layouts/markdown_layout.html.erb
@@ -1,8 +1,10 @@
 <% wrapped_content=capture do %>
   <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row govuk-width-container dfe-width-container">
-      <div class="govuk-grid-column-two-thirds">
-        <%= yield %>
+    <div class="dfe-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= yield %>
+        </div>
       </div>
     </div>
   </div>

--- a/layouts/markdown_resource.html.erb
+++ b/layouts/markdown_resource.html.erb
@@ -1,13 +1,15 @@
 <% wrapped_content=capture do %>
   <div class="govuk-main-wrapper">
-    <div class="govuk-grid-row govuk-width-container dfe-width-container markdown-resource content-section--<%= @item[:colour] ?  @item[:colour] : 'purple' %> two-column-page">
-      <div class="govuk-grid-column-two-thirds">
-        <%= yield %>
-        <%= render '/partials/share_this_resource.*' %>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <hr class="govuk-section-break--thick govuk-section-break-feedback">
-        <%= render('/partials/feedback.*', colour: @item[:colour] || "purple") %>
+    <div class="dfe-width-container">
+      <div class="govuk-grid-row markdown-resource content-section--<%= @item[:colour] ?  @item[:colour] : 'purple' %> two-column-page">
+        <div class="govuk-grid-column-two-thirds">
+          <%= yield %>
+          <%= render '/partials/share_this_resource.*' %>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <hr class="govuk-section-break--thick govuk-section-break-feedback">
+          <%= render('/partials/feedback.*', colour: @item[:colour] || "purple") %>
+        </div>
       </div>
     </div>
   </div>

--- a/layouts/partials/breadcrumbs.html.erb
+++ b/layouts/partials/breadcrumbs.html.erb
@@ -1,19 +1,21 @@
 <% breadcrumbs_trail_without_home = breadcrumbs_trail[1..-1] %>
 <% if breadcrumbs_trail_without_home.size > 1 %>
-  <div class="govuk-grid-row govuk-width-container dfe-width-container govuk-!-margin-top-7">
-    <div class="govuk-grid-column-full">
-      <div class="govuk-breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-          <% breadcrumbs_trail_without_home.each do |ancestor| %>
-            <li class="govuk-breadcrumbs__list-item">
-              <% if ancestor && ancestor[:title] %>
-                <%= link_to(ancestor[:title], ancestor.path, class: 'govuk-breadcrumbs__link') %>
-              <% else %>
-                Title missing
-              <% end %>
-            </li>
-          <% end %>
-        </ol>
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row govuk-!-margin-top-7">
+      <div class="govuk-grid-column-full">
+        <div class="govuk-breadcrumbs">
+          <ol class="govuk-breadcrumbs__list">
+            <% breadcrumbs_trail_without_home.each do |ancestor| %>
+              <li class="govuk-breadcrumbs__list-item">
+                <% if ancestor && ancestor[:title] %>
+                  <%= link_to(ancestor[:title], ancestor.path, class: 'govuk-breadcrumbs__link') %>
+                <% else %>
+                  Title missing
+                <% end %>
+              </li>
+            <% end %>
+          </ol>
+        </div>
       </div>
     </div>
   </div>

--- a/layouts/workload_topic_section.html.erb
+++ b/layouts/workload_topic_section.html.erb
@@ -1,19 +1,19 @@
 <% wrapped_content=capture do %>
   <div class="govuk-main-wrapper two-column-page content-section--purple">
-    <div class="dfe-width-container govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l"><%= @item[:title] %></h1>
-        <p>
-          These resources are designed to help you address workload issues
-          with <%= @item[:title].downcase %> in your school.
-        </p>
+    <div class="dfe-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l"><%= @item[:title] %></h1>
+          <p>
+            These resources are designed to help you address workload issues
+            with <%= @item[:title].downcase %> in your school.
+          </p>
+        </div>
       </div>
-    </div>
-
-    <div class="dfe-width-container govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-grid-row dfe-width-container">
-          <div class="info-box">
+    
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="info-box govuk-!-margin-top-8">
             <div class="info-box__corner">
               <img src="/assets/images/i-icon.svg" alt="info icon">
             </div>
@@ -35,26 +35,18 @@
               have reduced <%= @item[:title].downcase %> workload.
             </p>
           </div>
+
+          <h2 class="govuk-heading-m">
+            Resources to help <%= @item[:title].downcase %> workload
+          </h2>
+
+          <%= yield %>
         </div>
 
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-m">
-              Resources to help <%= @item[:title].downcase %> workload
-            </h2>
-          </div>
+        <div class="govuk-grid-column-one-third">
+          <hr class="govuk-section-break--blue govuk-section-break--thick">
+          <%= render '/partials/feedback.*', colour: "purple" %>
         </div>
-
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <%= yield %>
-          </div>
-        </div>
-      </div>
-
-      <div class="govuk-grid-column-one-third">
-        <hr class="govuk-section-break--blue govuk-section-break--thick">
-        <%= render '/partials/feedback.*', colour: "purple" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Changes in this PR

- Remove govuk-width-container
- Use dfe-width-container correctly
- Remove unneeded rows and columns and containers which were adding too much padding on sides
- Space info boxes better on mobile

## Guidance to review

- Check that the grey info-boxes on topic sections and individual resources on mobile. They should be wider and better spaced than before.
- Check that the white edges no longer appear on landscape mobile.

<img width="459" alt="Screenshot 2024-03-25 at 09 59 37" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/c9a0b0be-fb5c-4bca-99a0-213663c23fd5">

![WhatsApp Image 2024-03-20 at 15 00 29](https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/80114916-761e-4e39-ab06-c4708ed3dc3a)
