### PR TITLE
[397] Link styles

### DIFF
--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -445,6 +445,11 @@ hr.section-break--thin {
   margin-right: govuk-spacing(7);
   align-items: center;
   line-height: 0;
+
+  p {
+    margin-bottom: 0;
+    font-size: 16px;
+  }
 }
 
 .share-resource__icon {

--- a/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/review-and-streamline-behaviour-management.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/behaviour-management/review-and-streamline-behaviour-management.md
@@ -29,13 +29,13 @@ The presentation includes:
           <img src="/assets/images/behaviour-management--review-and-streamline-behaviour-management.jpg" alt="Review and streamline behaviour management" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.pptx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.pptx">
             Download Microsoft PowerPoint
          </a>
          <p>
            PPTX, 181KB, 7 slides
          </p>
-         <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.odp">
+         <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline behaviour management.odp">
            Download OpenDocument Presentation
          </a>
          <p>

--- a/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
@@ -51,13 +51,13 @@ title: Review and streamline communications
                 <img src="/assets/images/communications--review-and-streamline-communications.jpg" alt="Review and streamline communications" class="dfe-file-preview-image">
               </div>
               <div class="govuk-grid-column-one-half">
-                <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.pptx">
+                <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.pptx">
                   Download Microsoft PowerPoint
                 </a>
                 <p>
                   PPTX, 101KB, 6 slides
                 </p>
-                <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
+                <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
                   Download OpenDocument Presentation
                 </a>
                 <p>

--- a/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/review-and-streamline-lesson-planning.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/curriculum-planning-and-delivery/review-and-streamline-lesson-planning.md
@@ -30,13 +30,13 @@ The presentation includes:
             <img src="/assets/images/curriculum-planning-and-delivery--review-and-streamline-lesson-planning.jpg" alt="Review and streamline lesson planning" class="dfe-file-preview-image">
           </div>
           <div class="govuk-grid-column-one-half">
-            <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.pptx">
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.pptx">
               Download Microsoft PowerPoint
             </a>
             <p>
               PPTX, 114KB, 9 slides
             </p>
-            <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.odp">
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline lesson planning.odp">
               Download OpenDocument Presentation
             </a>
             <p>

--- a/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
@@ -46,13 +46,13 @@ title: Review and streamline data management
                   <img src="/assets/images/data-management--review-and-streamline-data-management.jpg" alt="Review and streamline data management" class="dfe-file-preview-image">
                 </div>
                 <div class="govuk-grid-column-one-half">
-                 <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.pptx">
+                 <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.pptx">
                    Download Microsoft PowerPoint
                  </a>
                  <p>
                    PPTX, 114KB, 9 slides
                  </p>
-                 <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.odp">
+                 <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.odp">
                    Download OpenDocument Presentation
                  </a>
                  <p>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
@@ -42,13 +42,13 @@ title: Review and streamline feedback and marking
               </div>
               <div class="govuk-grid-column-one-half">
                 <div class="info-box__content">
-                  <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.pptx">
+                  <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.pptx">
                     Download Microsoft PowerPoint
                   </a>
                   <p>
                     PPTX, 92KB, 7 slides
                   </p>
-                  <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
+                  <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
                     Download OpenDocument Presentation
                   </a>
                   <p>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-marking-practice-with-an-impact-matrix.md
@@ -70,13 +70,13 @@ create and complete the impact matrix.
         </div>
         <div class="govuk-grid-column-one-half">
           <div class="info-box__content">
-             <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.docx">
+             <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.docx">
               Download Microsoft Word Document
             </a>
             <p>
               DOCX, 25KB, 1 page
             </p>
-            <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.odt">
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact matrix.odt">
               Download OpenDocument Text
             </a>
             <p>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/evaluate-progress-with-staff.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/evaluate-progress-with-staff.md
@@ -24,13 +24,13 @@ your school. Gather feedback and evaluate if any actions taken have had an impac
           <img src="/assets/images/identify--share-progress-with-staff.jpg" alt="Share progress with staff" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 27KB, 1 page
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
             Download OpenDocument Text
           </a>
           <p>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/staff-workload-survey.md
@@ -50,13 +50,13 @@ refine any actions you’ve taken to reduce workload.
           <img src="/assets/images/identify-and-evaluate-survey.jpeg" alt="Staff workload survey" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 31KB, 4 pages
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
             Download OpenDocument Text
           </a>
           <p>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/structured-conversations-with-staff.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/structured-conversations-with-staff.md
@@ -23,13 +23,13 @@ A structured conversation template to help gather feedback from staff and teache
           <img src="/assets/images/evaluate--structured-conversation-template.jpg" alt="Structured conversation template" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.docx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 28KB, 1 page
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.odt">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Evaluate structured conversation template.odt">
             Download OpenDocument Text
           </a>
           <p>

--- a/content/workload-reduction-toolkit/evaluate-workload-measures/update-your-workload-action-plan.md
+++ b/content/workload-reduction-toolkit/evaluate-workload-measures/update-your-workload-action-plan.md
@@ -37,13 +37,13 @@ colour: green
           <img src="/assets/images/identify-and-evaluate--action-plan.jpg" alt="Workload action plan" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 29KB, 2 pages
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
             Download OpenDocument Text
           </a>
           <p>

--- a/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/act-on-your-staff-workload-survey.md
@@ -28,13 +28,13 @@ staff workload survey, prioritise next steps and identify:
           <img src="/assets/images/identify--act-on-your-staff-survey.jpg" alt="Act on your staff workload survey" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.pptx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.pptx">
             Download Microsoft PowerPoint
           </a>
           <p>
             PPTX, 90KB, 4 slides
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.odp">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Act on the staff workload survey.odp">
             Download OpenDocument Presentation
           </a>
           <p>

--- a/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/create-an-action-plan-to-reduce-workload.md
@@ -51,13 +51,13 @@ taken, what success looks like and the timescale for actions to be taken.
         </div>
         <div class="govuk-grid-column-one-half">
           <div class="info-box__content">
-             <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
+             <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
               Download Microsoft Word Document
             </a>
             <p>
               DOCX, 29KB, 2 pages
             </p>
-            <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/Workload and wellbeing action plan.docx">
               Download OpenDocument Text
             </a>
             <p>

--- a/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/have-structured-conversations-to-identify-issues.md
@@ -24,13 +24,13 @@ teachers about their workload issues.
           <img src="/assets/images/identify--have-structured-conversations-with-staff.jpg" alt="Have structured conversations to identify issues" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.docx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 26KB, 1 page
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.odt">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Identify structured conversation template.odt">
             Download OpenDocument Text
           </a>
           <p>

--- a/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/plan-your-yearly-calendar.md
@@ -30,13 +30,13 @@ The presentation includes:
           <img src="/assets/images/identify--plan-your-yearly-calendar.jpg" alt="Plan your yearly calendar" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.pptx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.pptx">
             Download Microsoft PowerPoint
           </a>
           <p>
             PPTX, 115KB, 9 slides
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.odp">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Plan your yearly calendar.odp">
             Download OpenDocument Presentation
           </a>
           <p>

--- a/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/prioritise-change-using-impact-graphs.md
@@ -25,13 +25,13 @@ one-to-ones, or in team or whole staff meetings.
           <img src="/assets/images/identify--prioritise-change-using-impact-graphs.jpg" alt="Prioritise change using impact graphs" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-           <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Impact graph.docx">
+           <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact graph.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 31KB, 1 page
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Impact graph.odt">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Impact graph.odt">
             Download OpenDocument Text
           </a>
           <p>

--- a/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/share-progress-with-staff.md
@@ -24,13 +24,13 @@ workload issues identified in your school.
           <img src="/assets/images/identify--share-progress-with-staff.jpg" alt="Share progress with staff" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-           <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
+           <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 27KB, 1 page
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Share progress with staff template.odt">
             Download OpenDocument Text
           </a>
           <p>

--- a/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
+++ b/content/workload-reduction-toolkit/identify-workload-issues/staff-workload-survey.md
@@ -49,13 +49,13 @@ resources from the workload reduction toolkit.
           <img src="/assets/images/identify-and-evaluate-survey.jpeg" alt="Staff workload survey" class="dfe-file-preview-image">
         </div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.docx">
             Download Microsoft Word Document
           </a>
           <p>
             DOCX, 31KB, 4 pages
           </p>
-          <a class="govuk-link--no-visited-state govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
+          <a class="govuk-body" href="<%= @base_url %>/assets/files/Staff workload survey.odt">
             Download OpenDocument Text
           </a>
           <p>

--- a/layouts/partials/share_this_resource.html.erb
+++ b/layouts/partials/share_this_resource.html.erb
@@ -4,14 +4,20 @@
     <div class="share-resource__icon <%= @item[:colour] ? 'share-resource__icon--' + @item[:colour] : nil %>">
       <img src="<%= base_url %>/assets/images/link-icon.svg" alt="Link icon"/>
     </div>
-    <button onclick="window.navigator.clipboard.writeText(window.location.href);" class="button-link">
-      Copy link
-    </button>
+    <p>
+      <button onclick="window.navigator.clipboard.writeText(window.location.href);" class="govuk-link button-link">
+        Copy link
+      </button>
+    </p>
   </div>
   <div class="share-resource">
     <div class="share-resource__icon <%= @item[:colour] ? 'share-resource__icon--' + @item[:colour] : nil %>">
       <img src="<%= base_url %>/assets/images/mail-icon.svg" alt="Mail icon"/>
     </div>
-    <a href="mailto:school.workloadandwellbeing@education.gov.uk?subject=Resource to help with workload and wellbeing for school staff&body=Check out <%= @item[:title] %> to help improve workload and wellbeing for staff in your school: <%= base_url %><%= @item.path %>">Email</a>
+    <p>
+      <a href="mailto:school.workloadandwellbeing@education.gov.uk?subject=Resource to help with workload and wellbeing for school staff&body=Check out <%= @item[:title] %> to help improve workload and wellbeing for staff in your school: <%= base_url %><%= @item.path %>">
+        Email
+      </a>
+    </p>
   </div>
 </div>


### PR DESCRIPTION
## Changes in this PR

- Remove 'govuk-link--no-visited-state' class from download links
- Fix styles on share links so that the standard govuk yellow background is applied when active

## Guidance to review

https://trello.com/c/bjyMFQ4m/397-fix-active-states-on-copy-link-and-email-link-and-remove-no-visited-state-class-on-download-links

- On resources, check that the download links turn purpler once visited
- Check that the active styles for both links in the Share this resource section are correct (standard yellow)

<img width="317" alt="Screenshot 2024-03-18 at 15 21 45" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/a92c30db-a167-4e0b-80b5-669e46875a5e">
