### PR TITLE
[398] Text bleed on cookies page at 400%

### DIFF
--- a/content/cookie-policy.html.erb
+++ b/content/cookie-policy.html.erb
@@ -45,7 +45,7 @@ title: Cookie policy
           </thead>
           <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell">_consented_to_analytics_cookies</td>
+                <td class="govuk-table__cell">_consented_to<wbr>_analytics_cookies</td>
                 <td class="govuk-table__cell">Saves your cookie consent settings</td>
                 <td class="govuk-table__cell">1 year</td>
             </tr>


### PR DESCRIPTION
## Changes in this PR

Allow an optional line break in the cookie name so that the table doesn't bleed off screen at 400%.

## Guidance to review

https://trello.com/c/LdzIyc8O/398-fix-text-bleed-at-400-zoom

Zoom in browser to 400% and check the cookies table fits on the screen:

<img width="1508" alt="Screenshot 2024-03-20 at 12 44 14" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/70e713cf-a45b-4076-a680-62ea40e3dc6f">

## Out of scope

Investigated keeping the footer from touching the edge of the screen but we're limited by the length of our email address:

![Screenshot 2024-03-20 at 12 26 55](https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/ef99dfff-fa92-4a23-b071-3406853522df)