### PR TITLE
[404] Add margin to bottom of explore resource tags

### DIFF
--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -35,6 +35,10 @@ $card-text-hover-color: govuk-colour("purple");
   }
 }
 
+.explore-resource-card__tag {
+  margin-bottom: govuk-spacing(2);
+}
+
 .resource-card {
   @include govuk-responsive-padding(5);
   border: $card-border-width solid govuk-colour("mid-grey");

--- a/layouts/partials/explore_resource_card.html.erb
+++ b/layouts/partials/explore_resource_card.html.erb
@@ -6,7 +6,7 @@
       <p class="govuk-body">Topic</p>
     </div>
     <div>
-      <strong class="govuk-tag<%= defined?(tag_colour) && " govuk-tag--#{tag_colour}" %>"><%= tag %></strong>
+      <strong class="explore-resource-card__tag govuk-tag<%= defined?(tag_colour) && " govuk-tag--#{tag_colour}" %>"><%= tag %></strong>
     </div>
   </div>
 


### PR DESCRIPTION
## Changes in this PR

Added margin to the tags on the explore resources pages.

Investigated making the font smaller on mobile, but it's already at the smallest recommended font size (16px).

May improve further when [this PR](https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/pull/93) is merged (it reduces the borders on mobile)

## Guidance to review

https://trello.com/c/sTEOHWkT/404-investigate-section-tags-on-the-explore-resources-page-potentially-making-the-font-smaller-or-tweaking-the-spacing

Head to the explore resources page and check that the tags look better.

<img width="447" alt="Screenshot 2024-03-21 at 16 00 06" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/d517ae6b-3bb2-482b-80ba-5b51c908e2b9">

