### PR TITLE
Apply fixes from cognitive walkthrough

### DIFF
--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -76,6 +76,17 @@
   }
 }
 
+@media (max-width: 48.0525em) {
+  .dfe-header__logo {
+    max-width: 100%;
+  }
+}
+@media (max-width: 450px) {
+  .dfe-header__logo {
+    max-width: 100%;
+  }
+}
+
 .govuk-breadcrumbs__list-item {
   font-size: 1rem;
 }

--- a/layouts/base.html.erb
+++ b/layouts/base.html.erb
@@ -21,9 +21,9 @@
   <header class="dfe-header" role="banner">
     <div class="dfe-width-container dfe-header__container">
       <div class="dfe-header__logo">
-        <a class="dfe-header__link dfe-header__link--service " href="<%= @base_url %>/main" aria-label="DfE homepage">
-          <img src="<%= @base_url %>/assets/images/dfe-logo.png" class="dfe-logo" alt="DfE Homepage">
-          <img src="<%= @base_url %>/assets/images/dfe-logo-alt.png" class="dfe-logo-hover" alt="DfE Homepage">
+        <a class="dfe-header__link dfe-header__link--service " href="<%= @base_url %>/main" aria-label="Department for Education homepage">
+          <img src="<%= @base_url %>/assets/images/dfe-logo.png" class="dfe-logo" alt="Department for Education Homepage">
+          <img src="<%= @base_url %>/assets/images/dfe-logo-alt.png" class="dfe-logo-hover" alt="Department for Education Homepage">
           <span class="dfe-header__service-name">
             Improve workload and wellbeing for school staff
           </span>
@@ -131,7 +131,7 @@
             </li>
           </ul>
           <div class="govuk-footer__contact">
-            <p class="govuk-footer__contact-title">Contact us for support</p>
+            <h3 class="govuk-footer__contact-title">Contact us for support</h3>
             <p class="govuk-footer__contact-description">
               Contact us via this email:
               <a href="mailto:school.workloadandwellbeing@education.gov.uk"


### PR DESCRIPTION
## Checklist

- [x] The alt-text for the DFE banner should be 'department for education', not 'DFE'
- [x] Contact us for support should be a header, not a paragraph
- [x] When you click the menu button, you can't see the change, because the service name is so long. Investigate how to make this look better.

## Hidden menu fix

To try to resolve this we have removed the `max-width` of the header logo and text. This results in the menu button moving below the header and closer to where the menu will appear.


https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/85567720/ccfa75de-4eed-433d-943f-c50cfe6f47a7

