### PR TITLE
Add skip link for screen readers

### DIFF
--- a/layouts/base.html.erb
+++ b/layouts/base.html.erb
@@ -16,6 +16,8 @@
 <body class="govuk-template__body js-enabled">
   <%= render '/partials/cookies_banner.*' %>
 
+  <%= render '/partials/skip_link.*' %>
+
   <%= render '/partials/tag_manager_body.*' %>
 
   <header class="dfe-header" role="banner">

--- a/layouts/partials/skip_link.html.erb
+++ b/layouts/partials/skip_link.html.erb
@@ -1,0 +1,6 @@
+<a
+  href="<%= "#{base_url}#{@item.path}" %>#main-content"
+  class="govuk-skip-link"
+  data-module="govuk-skip-link"
+  >Skip to main content</a
+>


### PR DESCRIPTION
## How to test

- [x] Select the url bar in the browser
- [x] Hit tab, the skip link should appear
- [x] Hit "Enter", the skip link should disappear and you should jump to the main content
- [x] Repeat on other pages...

https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/85567720/dd69a6c3-fc9f-473b-94f2-7d172f64197e

