### PR TITLE
Amend wellbeing box on homepage and wellbeing main page

### DIFF
--- a/content/staff-wellbeing.html.erb
+++ b/content/staff-wellbeing.html.erb
@@ -8,8 +8,10 @@ title: Staff wellbeing
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-4">Staff wellbeing</h1>
         <p class="govuk-body dfe-body-wrapped-text">
-          Promote a culture of wellbeing in your school and make a shared commitment to the education staff wellbeing
-          charter.
+          Promote a culture of wellbeing in your school and sign up to the
+          <a href="https://www.gov.uk/guidance/education-staff-wellbeing-charter">education staff wellbeing charter</a>
+          . The charter is a set of shared commitments from government, Ofsted, schools and colleges to protect and
+          promote the wellbeing of staff.
         </p>
       </div>
       <div class="govuk-grid-column-one-third">
@@ -32,12 +34,17 @@ title: Staff wellbeing
             How to use this section
           </h2>
           <p>
-            Placing staff wellbeing at the centre of everything you do will have
-            positive consequences in all aspects of school life.
+            Placing staff wellbeing at the centre of everything you do will have a positive impact on all aspects of
+            school life.
           </p>
           <p>
-            The resources provide specific examples which have worked in
-            schools. You can use them as they are, or adapt them to meet the needs of your school.
+            These resources have been shared by school leaders and provide specific examples that have worked in
+            schools. You can use them as they are, or adapt them to meet the needs of your setting.
+          </p>
+          <p>
+            The
+            <a href="https://www.gov.uk/guidance/education-staff-wellbeing-charter">education staff wellbeing charter</a>
+            also contains a range of additional wellbeing resources, including guidance to measure staff wellbeing.
           </p>
         </div>
 
@@ -106,19 +113,21 @@ title: Staff wellbeing
         <hr class="govuk-section-break--thick govuk-!-margin-top-6">
 
         <h2 class="govuk-heading-m govuk-!-padding-bottom-6">
-          Promote wellbeing and flexible working in your school
+          Promote flexible working and support staff mental health in your school
         </h2>
 
         <div class="govuk-!-padding-bottom-6">
           <p>
-            <a href="https://www.gov.uk/guidance/education-staff-wellbeing-charter">
-              Education staff wellbeing charter
-            </a>
+            Learn about the benefits of flexible working and how you can implement it in your school.
           </p>
           <p>
             <a href="https://www.gov.uk/guidance/get-help-with-flexible-working-in-schools">
               Flexible working toolkit
             </a>
+          </p>
+          <p>
+            Learn about different tools available to you to support staff mental health and pick the ones that fit best
+            for your setting.
           </p>
           <p>
             <a href="<%= @base_url %>/staff-wellbeing/supporting-staff-mental-health">


### PR DESCRIPTION
## Changes

- [ ] wellbeing box on the homepage
- [ ] the wellbeing page:
  - [ ] intro line under the page title
  - [ ] the ‘how to’ box
  - [ ] the ‘promote wellbeing…’ section to the right hand side of the page

![image](https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/85567720/f4d1562b-892d-4328-95fa-3bd5a5423988)
