### PR TITLE
[407] Fix spacing and update content on homepage

### DIFF
--- a/content/assets/css/_cards.scss
+++ b/content/assets/css/_cards.scss
@@ -136,8 +136,7 @@ $card-text-hover-color: govuk-colour("purple");
   margin-bottom: 0;
   padding: 0;
 
-  .icon-card,
-  .dfe-card {
+  .icon-card {
     margin-bottom: govuk-spacing(8);
   }
 
@@ -182,20 +181,28 @@ $card-text-hover-color: govuk-colour("purple");
 .dfe-card-container {
   @include govuk-media-query($from: tablet) {
     display: flex;
+    justify-content: space-between;
+    margin-bottom: govuk-spacing(7);
+
+    .dfe-card:not(:last-child) {
+      margin-right: 85px;
+    }
   }
 }
 
 .dfe-card {
+  flex: 1;
   display: flex;
   align-items: center;
-  width: 100%;
   margin: govuk-spacing(3);
   background-color: #347ca9;
   text-decoration: none;
 
   @include govuk-media-query($from: tablet) {
-    margin: 20px;
+    align-items: flex-start;
+    margin: govuk-spacing(3);
     border: 1px solid #b1b4b6;
+    background-color: govuk-colour("white");
   }
 }
 
@@ -223,6 +230,14 @@ $card-text-hover-color: govuk-colour("purple");
   }
 
   &:focus {
+    p {
+      color: govuk-colour("black");
+    }
+
+    .dfe-card__chevron {
+      background-color: $govuk-focus-colour;
+    }
+
     .dfe-card-header {
       color: govuk-colour("black");
       background-color: $govuk-focus-colour;
@@ -231,13 +246,14 @@ $card-text-hover-color: govuk-colour("purple");
 
     .dfe-card-body {
       background-color: $govuk-focus-colour;
-      p {
-        color: govuk-colour("black");
-      }
 
       @include govuk-media-query($from: tablet) {
         background-color: govuk-colour("white");
       }
+    }
+
+    @include govuk-media-query($from: tablet) {
+      background-color: govuk-colour("white");
     }
   }
 }
@@ -249,34 +265,32 @@ $card-text-hover-color: govuk-colour("purple");
 }
 
 .dfe-card-header {
-  padding: govuk-spacing(4);
-  padding-bottom: 0;
   margin: 0;
+  padding: govuk-spacing(4) govuk-spacing(3);
+  padding-bottom: 0;
+  background-color: #347ca9;
   color: govuk-colour("white");
-  font-weight: bold;
-  font-size: 19px;
 
   @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(7);
     font-size: 22px;
-    padding: govuk-spacing(7) govuk-spacing(6);
   }
 }
 
 .dfe-card-body {
-  padding: govuk-spacing(4);
-  padding-top: govuk-spacing(3);
+  padding: govuk-spacing(3);
 
   p {
-    color: govuk-colour("white");
     margin-bottom: 0;
+    color: govuk-colour("white");
   }
 
   @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(7);
+    padding-bottom: govuk-spacing(9);
     background-color: govuk-colour("white");
 
     p {
-      margin-bottom: govuk-spacing(7);
       color: $govuk-text-colour;
     }
   }
@@ -291,14 +305,14 @@ $card-text-hover-color: govuk-colour("purple");
   }
 }
 
-.dfe-card--pink {
+.bg-pink {
   background-color: #d4357f;
 }
 
-.dfe-card--purple {
+.bg-purple {
   background-color: govuk-colour("purple");
 }
 
-.dfe-card--green {
+.bg-green {
   background-color: #279b91;
 }

--- a/content/assets/css/_feedback-sections.scss
+++ b/content/assets/css/_feedback-sections.scss
@@ -1,6 +1,12 @@
 .feedback-section-container {
+  margin-top: govuk-spacing(1);
+  margin-bottom: govuk-spacing(3);
+
   @include govuk-media-query($from: tablet) {
     display: flex;
+    .feedback-section:not(:last-child) {
+      margin-right: 80px;
+    }
   }
 }
 
@@ -28,7 +34,7 @@
   margin-top: govuk-spacing(4);
 
   @include govuk-media-query($from: tablet) {
-    margin: govuk-spacing(4) govuk-spacing(6) 0 govuk-spacing(6);
+    margin: 0 govuk-spacing(6);
   }
 }
 

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -199,7 +199,7 @@
   background-color: #003a69;
   color: #ffffff;
   padding: 12px 15px;
-  font-size: 1.5rem;
+  font-size: 19px;
   font-weight: bold;
 }
 

--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -408,7 +408,6 @@ hr.section-break--thin {
 }
 
 .govuk-footer {
-  margin-top: govuk-spacing(9);
   p,
   a {
     font-size: 1rem;

--- a/content/index.html.erb
+++ b/content/index.html.erb
@@ -27,30 +27,37 @@ title: Home
 
 <div class="govuk-main-wrapper">
   <div class="dfe-width-container">
-    <ul class="govuk-grid-row card-group govuk-!-margin-bottom-8">
-      <li class="govuk-grid-column-one-half card-group__item govuk-!-padding-4">
-        <%= render('/partials/tile.*', title: "Workload reduction toolkit",
-          body: "Support workload reduction with resources produced by school leaders.",
-          href: "#{@base_url}/workload-reduction-toolkit"
-        ) %>
-      </li>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="dfe-card-container">
+          <%= render('/partials/tile.*', title: "Workload reduction toolkit",
+            body: "Support workload reduction with resources produced by school leaders.",
+            href: "#{@base_url}/workload-reduction-toolkit",
+            colour: "blue"
+          ) %>
 
-      <li class="govuk-grid-column-one-half card-group__item govuk-!-padding-4">
-        <%= render('/partials/tile.*', title: "Staff wellbeing",
-          body: "Promote a culture of wellbeing with resources made by school leaders.",
-          href: "#{@base_url}/staff-wellbeing"
-        ) %>
-      </li>
-    </ul>
+          <%= render('/partials/tile.*', title: "Staff wellbeing",
+            body: "Promote a wellbeing culture with resources made by school leaders. Sign up to the education staff wellbeing charter and find out how to support staff mental health in your school.",
+            href: "#{@base_url}/staff-wellbeing",
+            colour: "blue"
+          ) %>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="dfe-content-page--row">
     <div class="govuk-grid-row dfe-width-container">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m">Explore all resources</h2>
-        <p class="govuk-body">Browse through all our staff wellbeing and workload reduction resources. They are
-        contributed by school leaders from their experiences improving workload and wellbeing in their schools.</p>
-        <a class="govuk-button govuk-button--blue govuk-!-margin-top-2" data-module="govuk-button"
+        <h2 class="govuk-heading-m">
+          Explore all resources
+        </h2>
+        <p class="govuk-body">
+          Browse through all our staff wellbeing and workload reduction
+          resources. They are contributed by school leaders from their
+          experiences improving workload and wellbeing in their schools.
+        </p>
+        <a class="govuk-button govuk-button--blue govuk-!-margin-top-1 govuk-!-margin-bottom-0" data-module="govuk-button"
           href="<%= @base_url %>/explore-all-resources/identify-workload-issues">
           Explore all resources
         </a>

--- a/content/workload-reduction-toolkit.html.erb
+++ b/content/workload-reduction-toolkit.html.erb
@@ -30,7 +30,7 @@ title: Workload reduction toolkit
   <div class="dfe-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Use the toolkit</h2>
+        <h2 class="govuk-heading-m govuk-!-margin-top-2 govuk-!-margin-bottom-6">Use the toolkit</h2>
       </div>
     </div>
 

--- a/layouts/partials/tile.html.erb
+++ b/layouts/partials/tile.html.erb
@@ -1,6 +1,6 @@
-<a class="dfe-card <%= defined?(colour) ? 'dfe-card--' + colour : nil %> dfe-card--clickable govuk-link--no-visited-state" href="<%= href %>">
+<a class="dfe-card <%= defined?(colour) && 'bg-' + colour %> dfe-card--clickable govuk-link--no-visited-state" href="<%= href %>">
   <div class="dfe-card-content">
-    <h2 class="dfe-card-header">
+    <h2 class="govuk-heading-m dfe-card-header <%= defined?(colour) && 'bg-' + colour %>">
       <%= title %>
     </h2>
     <div class="dfe-card-body">


### PR DESCRIPTION
## Changes in this PR

- Fix spacing around homepage tiles
- Update content on wellbeing tile
- Ensure homepage tiles stay the same size with different length content
- Fix spacing on Explore all resources section
- Fix spacing on full-width 'Share your ideas' and 'Help improve our service' section
- Fix spacing around Workload reduction toolkit 'Use the toolkit' title

## Guidance to review

- Compare pages to screenshots on Trello ticket: https://trello.com/c/F2Ov4Eeg/407-adjust-padding-and-spacing-for-the-main-landing-page-toolkit-landing-page
- **IMPORTANT** - check the page on mobile to check things still look ok!!

<img width="528" alt="Screenshot 2024-03-26 at 14 27 01" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/b5686684-8541-447d-bead-d6a5feba75a3">
