### PR TITLE
[416] Style tweaks to feedback sections on resource pages

### DIFF
--- a/content/assets/css/_feedback-sections.scss
+++ b/content/assets/css/_feedback-sections.scss
@@ -8,6 +8,10 @@
       margin-right: 80px;
     }
   }
+
+  .feedback-section__hidden_icon {
+    display: none;
+  }
 }
 
 .govuk-grid-column-one-third {
@@ -22,7 +26,21 @@
   }
 
   .feedback-section__icon {
-    img {
+    display: none;
+  }
+
+  .feedback-section__icon_header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 20px;
+
+    .govuk-heading-m {
+      margin: 0;
+    }
+
+    .feedback-section__hidden_icon {
+      display: block;
+      margin: 0 20px 0 0;
       width: 56px;
     }
   }
@@ -31,6 +49,7 @@
 .feedback-section {
   width: 100%;
   display: flex;
+  align-items: flex-start;
   margin-top: govuk-spacing(4);
 
   @include govuk-media-query($from: tablet) {
@@ -40,15 +59,7 @@
 
 .feedback-section__icon {
   margin-right: govuk-spacing(6);
-  img {
-    width: 67px;
-  }
-}
-
-.feedback-section__content {
-  .govuk-heading-m {
-    margin-top: 0 !important;
-  }
+  width: 67px;
 }
 
 // In markdown pages, we can't drop the feedback section in below the title /

--- a/layouts/partials/feedback.html.erb
+++ b/layouts/partials/feedback.html.erb
@@ -1,47 +1,35 @@
 <div class="govuk-grid-row feedback-section-container">
   <div class="feedback-section">
-    <div class="feedback-section__icon">
-      <img
-        src="<%= base_url %>/assets/images/idea-icon-<%= defined?(colour) ? colour : 'blue' %>.svg"
-        alt="Idea icon"
-        class="dfe-icon"
-      />
-    </div>
+    <img src="<%= base_url %>/assets/images/idea-icon-<%= defined?(colour) ? colour : 'blue' %>.svg" alt="Idea icon" class="feedback-section__icon" />
     <div class="feedback-section__content">
-      <h3 class="govuk-heading-m">Share your ideas</h3>
+      <div class="feedback-section__icon_header">
+        <img src="<%= base_url %>/assets/images/idea-icon-<%= defined?(colour) ? colour : 'blue' %>.svg" alt="Idea icon" class="feedback-section__hidden_icon" />
+        <h3 class="govuk-heading-m">Share your ideas</h3>
+      </div>
       <p class="govuk-body">
         You can help other school leaders by sharing what has worked in your
         school.
       </p>
       <p class="govuk-body">
-        <a
-          href="<%= base_url %>/share-your-ideas"
-          class="govuk-link govuk-link--no-visited-state"
-        >
+        <a href="<%= base_url %>/share-your-ideas" class="govuk-link govuk-link--no-visited-state">
           Share your ideas
         </a>
       </p>
     </div>
   </div>
   <div class="feedback-section">
-    <div class="feedback-section__icon">
-      <img
-        src="<%= base_url %>/assets/images/chat-icon-<%= defined?(colour) ? colour : 'blue' %>.svg"
-        alt="Chat icon"
-        class="dfe-icon"
-      />
-    </div>
+    <img src="<%= base_url %>/assets/images/chat-icon-<%= defined?(colour) ? colour : 'blue' %>.svg" alt="Chat icon" class="feedback-section__icon" />
     <div class="feedback-section__content">
-      <h3 class="govuk-heading-m">Help improve our service</h3>
+      <div class="feedback-section__icon_header">
+        <img src="<%= base_url %>/assets/images/chat-icon-<%= defined?(colour) ? colour : 'blue' %>.svg" alt="Chat icon" class="dfe-icon feedback-section__hidden_icon" />
+        <h3 class="govuk-heading-m">Help improve our service</h3>
+      </div>
       <p class="govuk-body">
         Your feedback will help us improve our service on workload and wellbeing
         for all school staff.
       </p>
       <p class="govuk-body">
-        <a
-          href="https://forms.office.com/e/sEhZxVyw29"
-          class="govuk-link govuk-link--no-visited-state"
-        >
+        <a href="https://forms.office.com/e/sEhZxVyw29" class="govuk-link govuk-link--no-visited-state">
           Complete our feedback form
         </a>
       </p>


### PR DESCRIPTION
## Changes in this PR

For 'Share your ideas' and 'Help improve our service' boxes in resources and topic pages:
- Position the icon in the same row as the heading
- Align the paragraph below so that it appears below the icon.

I achieved by including a second icon shown on resource pages but hidden on the homepage. The larger left-aligned homepage icon is conversely hidden on resource pages.

## Guidance to review

- Check the styling of the section on resource pages
- Check the styling is not broken on the homepage and Workload reduction toolkit page. They should be unchanged here.
- Check on mobile

<img width="515" alt="Screenshot 2024-03-28 at 11 52 01" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/451b92e2-6e3b-43ac-81ff-70ff926df18b">
