### PR TITLE
Move `dfe-width-container` outside of `govuk-grid-row` on resources

### DIFF
--- a/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/communications/review-and-streamline-communications.html.erb
@@ -3,171 +3,173 @@ title: Review and streamline communications
 ---
 
 <div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row two-column-page content-section--purple">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline communications</h1>
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row two-column-page content-section--purple">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline communications</h1>
 
-      <p class="govuk-!-margin-bottom-7">
-        <strong class="govuk-tag">Presentation</strong>
-      </p>
-      
-      <p>
-        Use this presentation in a staff meeting or INSET day to review and
-        streamline your internal and external communication processes.
-      </p>
+        <p class="govuk-!-margin-bottom-7">
+          <strong class="govuk-tag">Presentation</strong>
+        </p>
+        
+        <p>
+          Use this presentation in a staff meeting or INSET day to review and
+          streamline your internal and external communication processes.
+        </p>
 
-      <p>
-        The presentation includes:
-      </p>
+        <p>
+          The presentation includes:
+        </p>
 
-      <ul>
-        <li>
-          background and context about managing communications
-        </li>
-        <li>
-          a discussion to reflect on why we communicate and whether the
-          processes should be updated, streamlined or stopped altogether
-        </li>
-        <li>
-          a reflection on why we communicate
-        </li>
-        <li>
-          a discussion on whether current communication processes should be
-          updated, streamlined or stopped altogether
-        </li>
-      </ul>
+        <ul>
+          <li>
+            background and context about managing communications
+          </li>
+          <li>
+            a discussion to reflect on why we communicate and whether the
+            processes should be updated, streamlined or stopped altogether
+          </li>
+          <li>
+            a reflection on why we communicate
+          </li>
+          <li>
+            a discussion on whether current communication processes should be
+            updated, streamlined or stopped altogether
+          </li>
+        </ul>
 
-      <div class="info-box">
-        <div class="info-box__corner">
-          <img src="/assets/images/download-icon.svg" alt="Download icon">
+        <div class="info-box">
+          <div class="info-box__corner">
+            <img src="/assets/images/download-icon.svg" alt="Download icon">
+          </div>
+          <h2 class="govuk-heading-m">
+            Download the presentation
+          </h2>
+          <div class="govuk-grid-row info-box__download-content">
+            <div class="govuk-grid-column-one-half">
+              <img src="/assets/images/communications--review-and-streamline-communications.jpg" alt="Review and streamline communications" class="dfe-file-preview-image">
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.pptx">
+                Download Microsoft PowerPoint
+              </a>
+              <p>
+                PPTX, 101KB, 6 slides
+              </p>
+              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
+                Download OpenDocument Presentation
+              </a>
+              <p>
+                ODP, 301KB, 6 slides
+              </p>
+            </div>
+          </div>
         </div>
-        <h2 class="govuk-heading-m">
-          Download the presentation
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+          Audience
         </h2>
-        <div class="govuk-grid-row info-box__download-content">
-          <div class="govuk-grid-column-one-half">
-            <img src="/assets/images/communications--review-and-streamline-communications.jpg" alt="Review and streamline communications" class="dfe-file-preview-image">
-          </div>
-          <div class="govuk-grid-column-one-half">
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.pptx">
-              Download Microsoft PowerPoint
-            </a>
-            <p>
-              PPTX, 101KB, 6 slides
-            </p>
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline communications.odp">
-              Download OpenDocument Presentation
-            </a>
-            <p>
-              ODP, 301KB, 6 slides
-            </p>
-          </div>
+
+        <p>
+          The presentation and facilitator notes will support senior leadership
+          teams to run a staff meeting with the whole school, teams or
+          departments.
+        </p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          Presentation length
+        </h2>
+
+        <p>
+          The presentation should take 1 hour. You should also allocate time for
+          the facilitator to prepare the session for use in your school.
+        </p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          How to run with your staff
+        </h2>
+
+        <p>
+          You can run the exercises in a staff meeting or they can be completed
+          individually or by teams ahead of the meeting.
+        </p>
+
+        <p>
+          Supporting resources can be printed or shared digitally and they are
+          editable. For example, you could adapt the table to suit the needs of
+          the staff group, by populating the 'how' column or changing the 'who
+          we communicate with' column. If the group is largely teachers, they
+          could complete the table together to consider how, as teachers, they
+          communicate with other staff, each other, parents or governors.
+        </p>
+
+        <p>
+          You could address internal and external communications separately or
+          choose one to focus on for this exercise.
+        </p>
+
+        <p>
+          Senior leadership teams are likely to want to oversee the process.
+          You could consider if it is more appropriate for another member of
+          staff to facilitate the session and lead on follow-up. You could also
+          consider asking somebody independent to facilitate the workshop to
+          free up time to take part.
+        </p>
+
+        <p>
+          Provide a supportive environment for open and honest professional
+          dialogue.
+        </p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          Supporting resources
+        </h2>
+
+        <ul class="resource-card-group">
+          <%= render('/partials/resource_card_with_image.*', title: "How we communicate" ,
+            body: "A template to help you explore how effective and efficient your communications are." ,
+            image_url: "/assets/images/communications--how-we-communicate.jpg" ,
+            tag: "Template" , download_links: [
+              {
+                href: "#{@base_url}/assets/files/Review_school_communications.docx",
+                text: "Download Microsoft Word Document",
+                details: "DOCX, 25KB, 1 page",
+              },
+              {
+                href: "#{@base_url}/assets/files/Review_school_communications.odt",
+                text: "Download OpenDocument Text",
+                details: "ODP, 8KB, 1 page",
+              },
+            ]
+          ) %>
+
+          <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
+            body: "A template to help you prioritise what to address first." ,
+            image_url: "/assets/images/communications--impact-graph.jpg" ,
+            tag: "Template" , download_links: [
+              {
+                href: "#{@base_url}/assets/files/Impact graph.docx",
+                text: "Download Microsoft Word Document",
+                details: "DOCX, 31KB, 1 page",
+              },
+              {
+                href: "#{@base_url}/assets/files/Impact graph.odt",
+                text: "Download OpenDocument Text",
+                details: "ODP, 6KB, 1 page",
+              },
+            ]
+          ) %>
+        </ul>
+
+        <div class="govuk-!-margin-top-8">
+          <%= render '/partials/share_this_resource.*' %>
         </div>
       </div>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
-        Audience
-      </h2>
-
-      <p>
-        The presentation and facilitator notes will support senior leadership
-        teams to run a staff meeting with the whole school, teams or
-        departments.
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        Presentation length
-      </h2>
-
-      <p>
-        The presentation should take 1 hour. You should also allocate time for
-        the facilitator to prepare the session for use in your school.
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        How to run with your staff
-      </h2>
-
-      <p>
-        You can run the exercises in a staff meeting or they can be completed
-        individually or by teams ahead of the meeting.
-      </p>
-
-      <p>
-        Supporting resources can be printed or shared digitally and they are
-        editable. For example, you could adapt the table to suit the needs of
-        the staff group, by populating the 'how' column or changing the 'who
-        we communicate with' column. If the group is largely teachers, they
-        could complete the table together to consider how, as teachers, they
-        communicate with other staff, each other, parents or governors.
-      </p>
-
-      <p>
-        You could address internal and external communications separately or
-        choose one to focus on for this exercise.
-      </p>
-
-      <p>
-        Senior leadership teams are likely to want to oversee the process.
-        You could consider if it is more appropriate for another member of
-        staff to facilitate the session and lead on follow-up. You could also
-        consider asking somebody independent to facilitate the workshop to
-        free up time to take part.
-      </p>
-
-      <p>
-        Provide a supportive environment for open and honest professional
-        dialogue.
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        Supporting resources
-      </h2>
-
-      <ul class="resource-card-group">
-        <%= render('/partials/resource_card_with_image.*', title: "How we communicate" ,
-          body: "A template to help you explore how effective and efficient your communications are." ,
-          image_url: "/assets/images/communications--how-we-communicate.jpg" ,
-          tag: "Template" , download_links: [
-            {
-              href: "#{@base_url}/assets/files/Review_school_communications.docx",
-              text: "Download Microsoft Word Document",
-              details: "DOCX, 25KB, 1 page",
-            },
-            {
-              href: "#{@base_url}/assets/files/Review_school_communications.odt",
-              text: "Download OpenDocument Text",
-              details: "ODP, 8KB, 1 page",
-            },
-          ]
-        ) %>
-
-        <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
-          body: "A template to help you prioritise what to address first." ,
-          image_url: "/assets/images/communications--impact-graph.jpg" ,
-          tag: "Template" , download_links: [
-            {
-              href: "#{@base_url}/assets/files/Impact graph.docx",
-              text: "Download Microsoft Word Document",
-              details: "DOCX, 31KB, 1 page",
-            },
-            {
-              href: "#{@base_url}/assets/files/Impact graph.odt",
-              text: "Download OpenDocument Text",
-              details: "ODP, 6KB, 1 page",
-            },
-          ]
-        ) %>
-      </ul>
-
-      <div class="govuk-!-margin-top-8">
-        <%= render '/partials/share_this_resource.*' %>
+      <div class="govuk-grid-column-one-third">
+        <hr class="govuk-section-break--thick govuk-section-break-feedback">
+        <%= render '/partials/feedback.*', colour: "purple" %>
       </div>
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <hr class="govuk-section-break--thick govuk-section-break-feedback">
-      <%= render '/partials/feedback.*', colour: "purple" %>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/data-management/review-and-streamline-data-management.html.erb
@@ -3,145 +3,147 @@ title: Review and streamline data management
 ---
 
 <div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row two-column-page content-section--purple">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline data management</h1>
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row two-column-page content-section--purple">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline data management</h1>
 
-      <p class="govuk-!-margin-bottom-7">
-        <strong class="govuk-tag">Presentation</strong>
-      </p>
+        <p class="govuk-!-margin-bottom-7">
+          <strong class="govuk-tag">Presentation</strong>
+        </p>
 
-      <p>
-        Use this presentation in a staff meeting or INSET day to review and
-        streamline your data management processes.
-      </p>
+        <p>
+          Use this presentation in a staff meeting or INSET day to review and
+          streamline your data management processes.
+        </p>
 
-      <p>
-        The presentation includes:
-      </p>
+        <p>
+          The presentation includes:
+        </p>
 
-      <ul>
-        <li>
-          background and context
-        </li>
-        <li>
-          a discussion to understand better why data is collected and how
-          collections can be streamlined or stopped altogether
-        </li>
-        <li>
-          a further discussion to decide what data is collected and not
-          collected in future
-        </li>
-      </ul>
+        <ul>
+          <li>
+            background and context
+          </li>
+          <li>
+            a discussion to understand better why data is collected and how
+            collections can be streamlined or stopped altogether
+          </li>
+          <li>
+            a further discussion to decide what data is collected and not
+            collected in future
+          </li>
+        </ul>
 
-      <div class="info-box">
-        <div class="info-box__corner">
-          <img src="/assets/images/download-icon.svg" alt="Download icon">
-        </div>
-        <h2 class="govuk-heading-m">
-          Download the presentation
-        </h2>
-        <div class="govuk-grid-row info-box__download-content">
-          <div class="govuk-grid-column-one-half">
-            <img src="/assets/images/data-management--review-and-streamline-data-management.jpg" alt="Review and streamline data management" class="dfe-file-preview-image">
+        <div class="info-box">
+          <div class="info-box__corner">
+            <img src="/assets/images/download-icon.svg" alt="Download icon">
           </div>
-          <div class="govuk-grid-column-one-half">
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.pptx">
-              Download Microsoft PowerPoint
-            </a>
-            <p>
-              PPTX, 114KB, 9 slides
+          <h2 class="govuk-heading-m">
+            Download the presentation
+          </h2>
+          <div class="govuk-grid-row info-box__download-content">
+            <div class="govuk-grid-column-one-half">
+              <img src="/assets/images/data-management--review-and-streamline-data-management.jpg" alt="Review and streamline data management" class="dfe-file-preview-image">
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.pptx">
+                Download Microsoft PowerPoint
+              </a>
+              <p>
+                PPTX, 114KB, 9 slides
+              </p>
+              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.odp">
+                Download OpenDocument Presentation
+              </a>
+              <p>
+                ODP, 119KB, 9 slides
             </p>
-            <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline data management.odp">
-              Download OpenDocument Presentation
-            </a>
-            <p>
-              ODP, 119KB, 9 slides
-          </p>
+            </div>
           </div>
+        </div>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+          Audience
+        </h2>
+
+        <p>
+          The presentation has been provided for senior leadership teams to run
+          with the whole school, teams or departments.  
+        </p>
+
+        <p>
+          It could also be an exercise just for senior leadership, with the
+          results shared and discussed with staff. 
+        </p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          Presentation length
+        </h2>
+
+        <p>
+          The presentation should take 1 hour. You should also allocate time for
+          the facilitator to prepare the session for use in your school.
+        </p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          How to run with your staff
+        </h2>
+
+        <p>
+          You could complete the exercises individually or in teams, before
+          discussing them together or communicating to the wider school.  
+        </p>
+
+        <p>
+          Senior leadership teams are likely to want to oversee the process. They
+          could also consider if it is more appropriate for another member of
+          staff to facilitate the session and lead on follow-up, for example, a
+          head of department. 
+        </p>
+
+        <p>
+          You might also wish to consider asking somebody independent to
+          facilitate the workshop to free up time to take part. 
+        </p>
+
+        <p>
+          Provide a supportive environment for open and honest professional
+          dialogue.
+        </p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          Supporting resources
+        </h2>
+
+        <ul class="resource-card-group">
+          <%= render('/partials/resource_card_with_image.*', title: "Review how data is collected" ,
+            body: "A template to help you review how data is collected." ,
+            image_url: "/assets/images/data-management--review-and-streamline-data-mangement.jpg" ,
+            tag: "Template" , download_links: [
+              {
+                href: "#{@base_url}/assets/files/Review how data is collected.docx",
+                text: "Download Microsoft Word Document",
+                details: "DOCX, 31KB, 1 page",
+              },
+              {
+                href: "#{@base_url}/assets/files/Review how data is collected.odt",
+                text: "Download OpenDocument Text",
+                details: "ODP, 6KB, 1 page",
+              },
+            ]
+          ) %>
+        </ul>
+
+        <div class="govuk-!-margin-top-8">
+          <%= render '/partials/share_this_resource.*' %>
         </div>
       </div>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
-        Audience
-      </h2>
-
-      <p>
-        The presentation has been provided for senior leadership teams to run
-        with the whole school, teams or departments.  
-      </p>
-
-      <p>
-        It could also be an exercise just for senior leadership, with the
-        results shared and discussed with staff. 
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        Presentation length
-      </h2>
-
-      <p>
-        The presentation should take 1 hour. You should also allocate time for
-        the facilitator to prepare the session for use in your school.
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        How to run with your staff
-      </h2>
-
-      <p>
-        You could complete the exercises individually or in teams, before
-        discussing them together or communicating to the wider school.  
-      </p>
-
-      <p>
-        Senior leadership teams are likely to want to oversee the process. They
-        could also consider if it is more appropriate for another member of
-        staff to facilitate the session and lead on follow-up, for example, a
-        head of department. 
-      </p>
-
-      <p>
-        You might also wish to consider asking somebody independent to
-        facilitate the workshop to free up time to take part. 
-      </p>
-
-      <p>
-        Provide a supportive environment for open and honest professional
-        dialogue.
-      </p>
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        Supporting resources
-      </h2>
-
-      <ul class="resource-card-group">
-        <%= render('/partials/resource_card_with_image.*', title: "Review how data is collected" ,
-          body: "A template to help you review how data is collected." ,
-          image_url: "/assets/images/data-management--review-and-streamline-data-mangement.jpg" ,
-          tag: "Template" , download_links: [
-            {
-              href: "#{@base_url}/assets/files/Review how data is collected.docx",
-              text: "Download Microsoft Word Document",
-              details: "DOCX, 31KB, 1 page",
-            },
-            {
-              href: "#{@base_url}/assets/files/Review how data is collected.odt",
-              text: "Download OpenDocument Text",
-              details: "ODP, 6KB, 1 page",
-            },
-          ]
-        ) %>
-      </ul>
-
-      <div class="govuk-!-margin-top-8">
-        <%= render '/partials/share_this_resource.*' %>
+      <div class="govuk-grid-column-one-third">
+        <hr class="govuk-section-break--thick govuk-section-break-feedback">
+        <%= render '/partials/feedback.*', colour: "purple" %>
       </div>
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <hr class="govuk-section-break--thick govuk-section-break-feedback">
-      <%= render '/partials/feedback.*', colour: "purple" %>
     </div>
   </div>
 </div>

--- a/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
+++ b/content/workload-reduction-toolkit/address-workload-issues/feedback-and-marking/review-and-streamline-feedback-and-marking.html.erb
@@ -3,141 +3,143 @@ title: Review and streamline feedback and marking
 ---
 
 <div class="govuk-main-wrapper">
-  <div class="dfe-width-container govuk-grid-row two-column-page content-section--purple">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline feedback and marking</h1>
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row two-column-page content-section--purple">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-3">Review and streamline feedback and marking</h1>
 
-      <p class="govuk-!-margin-bottom-7">
-        <strong class="govuk-tag">Presentation</strong>
-      </p>
+        <p class="govuk-!-margin-bottom-7">
+          <strong class="govuk-tag">Presentation</strong>
+        </p>
 
-      <p>
-        Use this presentation in a staff meeting or INSET day to review and
-        streamline your feedback and marking processes.
-      </p>
+        <p>
+          Use this presentation in a staff meeting or INSET day to review and
+          streamline your feedback and marking processes.
+        </p>
 
-      <p>
-        The presentation includes:
-      </p>
+        <p>
+          The presentation includes:
+        </p>
 
-      <ul>
-        <li>background and contextual information</li>
-        <li>the purposes of feedback and marking</li>
-        <li>reviewing current practice</li>
-        <li>next steps</li>
-      </ul>
+        <ul>
+          <li>background and contextual information</li>
+          <li>the purposes of feedback and marking</li>
+          <li>reviewing current practice</li>
+          <li>next steps</li>
+        </ul>
 
-      <div class="info-box">
-        <div class="info-box__corner">
-          <img src="/assets/images/download-icon.svg" alt="Download icon">
-        </div>
-        <h2 class="govuk-heading-m">
-          Download the presentation
-        </h2>
-        <div class="govuk-grid-row info-box__download-content">
-          <div class="govuk-grid-column-one-half">
-            <img src="/assets/images/feedback-and-marking--review-and-streamline-feedback-and-marking.jpg" alt="Review and streamline feedback and marking" class="dfe-file-preview-image">
+        <div class="info-box">
+          <div class="info-box__corner">
+            <img src="/assets/images/download-icon.svg" alt="Download icon">
           </div>
-          <div class="govuk-grid-column-one-half">
-            <div class="info-box__content">
-              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.pptx">
-                Download Microsoft PowerPoint
-              </a>
-              <p>
-                PPTX, 92KB, 7 slides
-              </p>
-              <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
-                Download OpenDocument Presentation
-              </a>
-              <p>
-                ODP, 177KB, 7 slides
-              </p>
+          <h2 class="govuk-heading-m">
+            Download the presentation
+          </h2>
+          <div class="govuk-grid-row info-box__download-content">
+            <div class="govuk-grid-column-one-half">
+              <img src="/assets/images/feedback-and-marking--review-and-streamline-feedback-and-marking.jpg" alt="Review and streamline feedback and marking" class="dfe-file-preview-image">
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <div class="info-box__content">
+                <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.pptx">
+                  Download Microsoft PowerPoint
+                </a>
+                <p>
+                  PPTX, 92KB, 7 slides
+                </p>
+                <a class="govuk-body" href="<%= @base_url %>/assets/files/Review and streamline feedback and marking.odp">
+                  Download OpenDocument Presentation
+                </a>
+                <p>
+                  ODP, 177KB, 7 slides
+                </p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
-        Audience
-      </h2>
+        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+          Audience
+        </h2>
 
-      <p>
-        This resource has been provided to support senior leadership teams to
-        run a session with the whole school, teams or departments.
-      </p>
+        <p>
+          This resource has been provided to support senior leadership teams to
+          run a session with the whole school, teams or departments.
+        </p>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        Presentation length
-      </h2>
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          Presentation length
+        </h2>
 
-      <p>
-        The presentation should take 1 hour and 15 minutes. You should also
-        allocate time for the facilitator to prepare the session for use in
-        your school.
-      </p>
+        <p>
+          The presentation should take 1 hour and 15 minutes. You should also
+          allocate time for the facilitator to prepare the session for use in
+          your school.
+        </p>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        How to run with your staff
-      </h2>
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          How to run with your staff
+        </h2>
 
-      <p>
-        Depending on the situation in your school, you might wish to use this
-        workshop as a starting point to initiate further exploration. You can
-        also use it to prepare for the workshop with activities beforehand.
-      </p>
-      <p>
-        This could include your senior leadership team discussing: 
-        <ul>
-          <li>to what extent teachers follow your existing policy – and how you know?</li>
-          <li>can you clearly articulate what you expect from teachers – and is it reasonable?</li>
-          <li>do you have evidence to support the practices in your current policy?</li>
-          <li>how does your policy compare with examples from other schools?</li>
+        <p>
+          Depending on the situation in your school, you might wish to use this
+          workshop as a starting point to initiate further exploration. You can
+          also use it to prepare for the workshop with activities beforehand.
+        </p>
+        <p>
+          This could include your senior leadership team discussing: 
+          <ul>
+            <li>to what extent teachers follow your existing policy – and how you know?</li>
+            <li>can you clearly articulate what you expect from teachers – and is it reasonable?</li>
+            <li>do you have evidence to support the practices in your current policy?</li>
+            <li>how does your policy compare with examples from other schools?</li>
+          </ul>
+        </p>
+        <p>
+          Senior leadership teams are likely to want to oversee the process.
+          However they may want to consider if another staff member could
+          facilitate the session and lead on follow-up, for example, a head of
+          department. Alternatively, you might want to consider asking an
+          independent person to facilitate the workshop, to free up time to take
+          part.
+        </p>
+        <p>
+          Provide a supportive environment for open and honest professional
+          dialogue.
+        </p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+          Supporting resources
+        </h2>
+
+        <ul class="resource-card-group">
+          <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
+            body: "A template to help you prioritise what to address first." ,
+            image_url: "/assets/images/communications--impact-graph.jpg" ,
+            tag: "Template" , download_links: [
+              {
+                href: "#{@base_url}/assets/files/Impact graph.docx",
+                text: "Download Microsoft Word Document",
+                details: "DOCX, 31KB, 1 page",
+              },
+              {
+                href: "#{@base_url}/assets/files/Impact graph.odt",
+                text: "Download OpenDocument Text",
+                details: "ODP, 6KB, 1 page",
+              },
+            ]
+          ) %>
         </ul>
-      </p>
-      <p>
-        Senior leadership teams are likely to want to oversee the process.
-        However they may want to consider if another staff member could
-        facilitate the session and lead on follow-up, for example, a head of
-        department. Alternatively, you might want to consider asking an
-        independent person to facilitate the workshop, to free up time to take
-        part.
-      </p>
-      <p>
-        Provide a supportive environment for open and honest professional
-        dialogue.
-      </p>
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
-        Supporting resources
-      </h2>
-
-      <ul class="resource-card-group">
-        <%= render('/partials/resource_card_with_image.*', title: "Impact graph" ,
-          body: "A template to help you prioritise what to address first." ,
-          image_url: "/assets/images/communications--impact-graph.jpg" ,
-          tag: "Template" , download_links: [
-            {
-              href: "#{@base_url}/assets/files/Impact graph.docx",
-              text: "Download Microsoft Word Document",
-              details: "DOCX, 31KB, 1 page",
-            },
-            {
-              href: "#{@base_url}/assets/files/Impact graph.odt",
-              text: "Download OpenDocument Text",
-              details: "ODP, 6KB, 1 page",
-            },
-          ]
-        ) %>
-      </ul>
-
-      <div class="govuk-!-margin-top-8">
-        <%= render '/partials/share_this_resource.*' %>
+        <div class="govuk-!-margin-top-8">
+          <%= render '/partials/share_this_resource.*' %>
+        </div>
       </div>
-    </div>
 
-    <div class="govuk-grid-column-one-third">
-      <hr class="govuk-section-break--thick govuk-section-break-feedback">
-      <%= render '/partials/feedback.*', colour: "purple" %>
+      <div class="govuk-grid-column-one-third">
+        <hr class="govuk-section-break--thick govuk-section-break-feedback">
+        <%= render '/partials/feedback.*', colour: "purple" %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Changes in this PR

For the content to render correctly, the `dfe-width-container` div should wrap the `govuk-grid-row` div. This was incorrect on a couple of pages to the content wasn't aligning properly e.g. on Communications presentation:

<img width="744" alt="Screenshot 2024-03-28 at 12 38 34" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/a934a18f-ad5f-4357-9656-5da503cbbdd8">

## Guidance to review

Now:

<img width="923" alt="Screenshot 2024-03-28 at 12 38 49" src="https://github.com/DFE-Digital/improve-workload-and-wellbeing-for-school-staff/assets/18436946/3257b770-a324-47b9-af90-afb9363453ce">

