### PR TITLE
Add presentation page template

### DIFF
--- a/docs/adding-a-resource.md
+++ b/docs/adding-a-resource.md
@@ -8,6 +8,8 @@ Useful links:
 
 - [Example resource file](example-resource.md)
 
+- [Example presentation file](example-presentation.md)
+
 - [Example pull request](https://github.com/DFE-Digital/improve-school-workload-and-wellbeing/pull/39) -
   this is an example pull request on Github, where a single resource has been
   added. If you make the same changes as in this pull request, you will also

--- a/docs/example-presentation.html.erb
+++ b/docs/example-presentation.html.erb
@@ -1,0 +1,147 @@
+---
+title: INSERT-TITLE
+---
+
+<div class="govuk-main-wrapper">
+  <div class="dfe-width-container govuk-grid-row two-column-page content-section--purple">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">INSERT-TITLE</h1>
+
+      <p class="govuk-!-margin-bottom-7">
+        <strong class="govuk-tag">Presentation</strong>
+      </p>
+
+      <p>
+        INSERT TEXT DESCRIBING HOW THIS PRESENTATION CAN BE USED
+      </p>
+
+      <p>
+        The presentation includes:
+      </p>
+
+      <ul>
+        <li>
+          HIGH-LEVEL PRESENTATION TOPIC 1
+        </li>
+        <li>
+          HIGH-LEVEL PRESENTATION TOPIC 2
+        </li>
+        <li>
+          HIGH-LEVEL PRESENTATION TOPIC 3
+        </li>
+        <li>
+          HIGH-LEVEL PRESENTATION TOPIC 4
+        </li>
+      </ul>
+
+      <div class="info-box">
+        <div class="info-box__corner">
+          <img src="/assets/images/download-icon.svg" alt="Download icon">
+        </div>
+        <h2 class="govuk-heading-m">
+          Download the presentation
+        </h2>
+        <div class="govuk-grid-row info-box__download-content">
+          <div class="govuk-grid-column-one-half">
+            <img src="/assets/images/preview-placeholder.jpg" alt="INSERT-TITLE" class="dfe-file-preview-image">
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/INSERT-FILENAME.pptx">
+              Download Microsoft PowerPoint
+            </a>
+            <p>
+              PPTX, INSERT-FILESIZE KB, X slides
+            </p>
+            <a class="govuk-body" href="<%= @base_url %>/assets/files/INSERT-FILENAME.odp">
+              Download OpenDocument Presentation
+            </a>
+            <p>
+              ODP, INSERT-FILESIZE KB, X slides
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-7">
+        Audience
+      </h2>
+
+      <p>
+        INSERT TEXT DESCRIBING THE INTENDED AUDIENCE FOR THIS PRESENTATION
+      </p>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Presentation length
+      </h2>
+
+      <p>
+        INSERT TEXT DESCRIBING THE LENGTH OF THIS PRESENTATION
+      </p>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        How to run with your staff
+      </h2>
+
+      <p>
+        INSERT TEXT DESCRIBING HOW TO RUN THIS PRESENTATION WITH YOUR STAFF
+      </p>
+
+      <p>
+        INSERT MULTIPLE PARAGRAPHS DESCRIBING HOW TO RUN THIS PRESENTATION WITH YOUR STAFF
+      </p>
+
+      <p>
+        ...
+      </p>
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+        Supporting resources
+      </h2>
+
+      <ul class="resource-card-group">
+        <%= render('/partials/resource_card_with_image.*', title: "INSERT-RESOURCE-TITLE" ,
+          body: "INSERT-RESOURCE-DESCRIPTION" ,
+          image_url: "/assets/images/preview-placeholder.jpg" ,
+          tag: "Template" , download_links: [
+            {
+              href: "#{@base_url}/assets/files/INSERT-FILENAME.docx",
+              text: "Download Microsoft Word Document",
+              details: "DOCX, INSERT-FILESIZE KB, X slides",
+            },
+            {
+              href: "#{@base_url}/assets/files/INSERT-FILENAME.odt",
+              text: "Download OpenDocument Text",
+              details: "ODP, INSERT-FILESIZE KB, X slides",
+            },
+          ]
+        ) %>
+
+        <%= render('/partials/resource_card_with_image.*', title: "INSERT-RESOURCE-TITLE" ,
+          body: "INSERT-RESOURCE-DESCRIPTION" ,
+          image_url: "/assets/images/preview-placeholder.jpg" ,
+          tag: "Template" , download_links: [
+            {
+              href: "#{@base_url}/assets/files/INSERT-FILENAME.docx",
+              text: "Download Microsoft Word Document",
+              details: "DOCX, INSERT-FILESIZE KB, X slides",
+            },
+            {
+              href: "#{@base_url}/assets/files/INSERT-FILENAME.odt",
+              text: "Download OpenDocument Text",
+              details: "ODP, INSERT-FILESIZE KB, X slides",
+            },
+          ]
+        ) %>
+      </ul>
+
+      <div class="govuk-!-margin-top-8">
+        <%= render '/partials/share_this_resource.*' %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <hr class="govuk-section-break--thick govuk-section-break-feedback">
+      <%= render '/partials/feedback.*', colour: "purple" %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Adding an example presentation page in the `docs` folder and linking to it from the "Adding a Resource" page.